### PR TITLE
Correct headers

### DIFF
--- a/Libraries/3rd/graphite2/CMakeLists.txt
+++ b/Libraries/3rd/graphite2/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(BEFORE
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/source/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/src
 )
 
 add_definitions(

--- a/Programs/DviWare/dvipdfm-x/source/dpxfile.c
+++ b/Programs/DviWare/dvipdfm-x/source/dpxfile.c
@@ -63,6 +63,11 @@
 #endif
 #endif
 
+#if defined(__APPLE__)
+#include <sys/syslimits.h>
+#  define _MAX_PATH     PATH_MAX
+#endif
+
 static int verbose = 0;
 int keep_cache = 0;
 


### PR DESCRIPTION
1) Adds a path so that the graphite2 headers can find one of their headers
2) makes the _MAX_PATH macro work on OS X, where the correct name is PATH_MAX