### PR TITLE
write_stream starts at zero and it is only 16 bit

### DIFF
--- a/Programs/TeXAndFriends/Knuth/tex/tex-miktex-src.ch
+++ b/Programs/TeXAndFriends/Knuth/tex/tex-miktex-src.ch
@@ -174,7 +174,7 @@ begin
       and miktex_is_new_source(source_filename_stack[in_open], line)) then
   begin
     new_whatsit (special_node, write_node_size);
-    write_stream(tail) := null;
+    write_stream(tail) := 0;
     def_ref := get_avail;
     token_ref_count(def_ref) := null;
     str_toks (miktex_make_src_special(source_filename_stack[in_open], line));


### PR DESCRIPTION
Write_stream is a stream number, the default figure should be zero rather than the NULL (which in the context of LaTeX is -268435455)