### PR TITLE
Prepend GS_LIB with existing paths (non-Windows)

### DIFF
--- a/Libraries/MiKTeX/Core/Session/init.cpp
+++ b/Libraries/MiKTeX/Core/Session/init.cpp
@@ -955,13 +955,14 @@ void SessionImpl::SetEnvironmentVariables()
   }
   MIKTEX_ASSERT(!gsDirectories.Empty());
 
-#if MIKTEX_WINDOWS
+#if defined(MIKTEX_WINDOWS)
   Utils::SetEnvironmentString("MIKTEX_GS_LIB", StringUtil::Flatten(gsDirectories, PathName::PathNameDelimiter));
 #else
-  string origGsDirs;
-  if (Utils::GetEnvironmentString("GS_LIB", origGsDirs))
+  string origGsLib;
+  if (Utils::GetEnvironmentString("GS_LIB", origGsLib))
   {
-    gsDirectories.push_back(origGsDirs);
+    vector<string> origGsLibDirectories = StringUtil::Split(origGsLib, PathName::PathNameDelimiter);
+    gsDirectories.insert(gsDirectories.end(), origGsLibDirectories.begin(), origGsLibDirectories.end());
   }
   Utils::SetEnvironmentString("GS_LIB", StringUtil::Flatten(gsDirectories, PathName::PathNameDelimiter));
 #endif

--- a/Libraries/MiKTeX/Core/Session/init.cpp
+++ b/Libraries/MiKTeX/Core/Session/init.cpp
@@ -924,6 +924,8 @@ void SessionImpl::SetEnvironmentVariables()
 
   // Ghostscript
   Utils::SetEnvironmentString("GSC", MIKTEX_GS_EXE);
+#endif
+
   vector<string> gsDirectories;
   PathName gsDir = GetSpecialPath(SpecialPath::CommonInstallRoot) / "ghostscript" / "base";
   if (Directory::Exists(gsDir))
@@ -952,7 +954,16 @@ void SessionImpl::SetEnvironmentVariables()
     }
   }
   MIKTEX_ASSERT(!gsDirectories.Empty());
+
+#if MIKTEX_WINDOWS
   Utils::SetEnvironmentString("MIKTEX_GS_LIB", StringUtil::Flatten(gsDirectories, PathName::PathNameDelimiter));
+#else
+  string origGsDirs;
+  if (Utils::GetEnvironmentString("GS_LIB", origGsDirs))
+  {
+    gsDirectories.push_back(origGsDirs);
+  }
+  Utils::SetEnvironmentString("GS_LIB", StringUtil::Flatten(gsDirectories, PathName::PathNameDelimiter));
 #endif
 
   PathName path = GetTempDirectory();


### PR DESCRIPTION
Something like this could resolve #393 for non-Windows operating systems, yielding consistent and platform-independent usage of URW++ fonts.