### PR TITLE
set empty username/password when "Requires Authentication" is unchecked

### DIFF
--- a/Libraries/MiKTeX/PackageManager/CurlWebSession.cpp
+++ b/Libraries/MiKTeX/PackageManager/CurlWebSession.cpp
@@ -208,6 +208,11 @@ void CurlWebSession::Initialize()
       userPassword += proxySettings.password;
       SetOption(CURLOPT_PROXYUSERPWD, userPassword.c_str());
     }
+    else
+    {
+        SetOption(CURLOPT_PROXYUSERNAME, "");
+        SetOption(CURLOPT_PROXYPASSWORD, "");
+    }
   }
 }
 


### PR DESCRIPTION
set empty username/password when "Requires Authentication" is unchecked to get kerberos authentication working

https://github.com/MiKTeX/miktex/issues/514