### PR TITLE
Initial support for native Apple Silicon target

### DIFF
--- a/Libraries/3rd/fontconfig/source/src/fcatomic.h
+++ b/Libraries/3rd/fontconfig/source/src/fcatomic.h
@@ -70,24 +70,16 @@ typedef LONG fc_atomic_int_t;
 #elif !defined(FC_NO_MT) && defined(__APPLE__)
 
 #include <libkern/OSAtomic.h>
-#ifdef __MAC_OS_X_MIN_REQUIRED
 #include <AvailabilityMacros.h>
-#elif defined(__IPHONE_OS_MIN_REQUIRED)
-#include <Availability.h>
-#endif
 
 typedef int fc_atomic_int_t;
 #define fc_atomic_int_add(AI, V)	(OSAtomicAdd32Barrier ((V), &(AI)) - (V))
 
 #define fc_atomic_ptr_get(P)		(OSMemoryBarrier (), (void *) *(P))
-#if (MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_4 || __IPHONE_VERSION_MIN_REQUIRED >= 20100)
+#if (MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_4 || __IPHONE_OS_VERSION_MIN_REQUIRED >= 20100)
 #define fc_atomic_ptr_cmpexch(P,O,N)	OSAtomicCompareAndSwapPtrBarrier ((void *) (O), (void *) (N), (void **) (P))
 #else
-#if __ppc64__ || __x86_64__
-#define fc_atomic_ptr_cmpexch(P,O,N)	OSAtomicCompareAndSwap64Barrier ((int64_t) (O), (int64_t) (N), (int64_t*) (P))
-#else
-#define fc_atomic_ptr_cmpexch(P,O,N)	OSAtomicCompareAndSwap32Barrier ((int32_t) (O), (int32_t) (N), (int32_t*) (P))
-#endif
+#error "Your macOS / iOS targets are too old"
 #endif
 
 #elif !defined(FC_NO_MT) && defined(HAVE_INTEL_ATOMIC_PRIMITIVES)

--- a/Libraries/MiKTeX/App/app.cpp
+++ b/Libraries/MiKTeX/App/app.cpp
@@ -599,7 +599,7 @@ void Application::Finalize()
 
 void Application::ReportLine(const string& str)
 {
-  MIKTEX_ASSERT(logger != nullptr);
+  MIKTEX_ASSERT(pimpl->logger != nullptr);
   LOG4CXX_INFO(pimpl->logger, "mpm: " << str);
   if (!GetQuietFlag())
   {

--- a/Libraries/MiKTeX/Core/Cfg/Cfg.cpp
+++ b/Libraries/MiKTeX/Core/Cfg/Cfg.cpp
@@ -1145,7 +1145,7 @@ void CfgImpl::Read(std::istream& reader, const string& defaultKeyName, int level
 
 bool CfgImpl::ParseValueDefinition(const string& line, string& valueName, string& value, CfgImpl::PutMode& putMode)
 {
-  MIKTEX_ASSERT(!line.empty() && (IsAlNum(line[0]) || line[0] == '.'));
+  MIKTEX_ASSERT(!line.empty() && (isalnum(line[0]) || line[0] == '.'));
 
   size_t posEqual = line.find('=');
 

--- a/Libraries/MiKTeX/Core/Fndb/FileNameDatabase.cpp
+++ b/Libraries/MiKTeX/Core/Fndb/FileNameDatabase.cpp
@@ -138,7 +138,7 @@ bool FileNameDatabase::Search(const PathName& relativePath, const string& pathPa
   trace_fndb->WriteLine("core", fmt::format(T_("fndb search: rootDirectory={0}, relativePath={1}, pathpattern={2}"), Q_(rootDirectory), Q_(relativePath), Q_(pathPattern)));
 
   MIKTEX_ASSERT(result.size() == 0);
-  MIKTEX_ASSERT(!PathNameUtil::IsAbsolutePath(relativePath));
+  MIKTEX_ASSERT(!PathNameUtil::IsAbsolutePath(relativePath.GetData()));
   MIKTEX_ASSERT(!IsExplicitlyRelativePath(relativePath.GetData()));
 
   PathName dir = relativePath.GetDirectoryName();

--- a/Libraries/MiKTeX/Core/Session/init.cpp
+++ b/Libraries/MiKTeX/Core/Session/init.cpp
@@ -1002,7 +1002,7 @@ unordered_map<string, string> SessionImpl::CreateChildEnvironment(bool changeDir
       gsDirectories.push_back(gsDir.ToString());
     }
   }
-  MIKTEX_ASSERT(!gsDirectories.Empty());
+  MIKTEX_ASSERT(!gsDirectories.empty());
 
 #if defined(MIKTEX_WINDOWS)
   envMap["MIKTEX_GS_LIB"] = StringUtil::Flatten(gsDirectories, PathNameUtil::PathNameDelimiter);

--- a/Libraries/MiKTeX/Core/Utils/Utils.cpp
+++ b/Libraries/MiKTeX/Core/Utils/Utils.cpp
@@ -326,7 +326,7 @@ bool Utils::GetUncRootFromPath(const PathName& path, PathName& uncRoot)
 
 bool Utils::GetPathNamePrefix(const PathName& path, const PathName& suffix, PathName& prefix)
 {
-  MIKTEX_ASSERT(!PathNameUtil::IsAbsolutePath(suffix));
+  MIKTEX_ASSERT(!PathNameUtil::IsAbsolutePath(suffix.GetData()));
 
   PathName path_(path);
   PathName suffix_(suffix);

--- a/Libraries/MiKTeX/Core/include/miktex/Core/ci_string.h
+++ b/Libraries/MiKTeX/Core/include/miktex/Core/ci_string.h
@@ -58,7 +58,7 @@ namespace std
     size_t operator()(const MiKTeX::Core::ci_string& str) const
     {
       // see http://www.isthe.com/chongo/tech/comp/fnv/index.html
-#if defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
+#if defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(__arch64__)
       MIKTEX_ASSERT(sizeof(size_t) == 8);
       const size_t FNV_prime = 1099511628211ULL;
       const size_t offset_basis = 14695981039346656037ULL;

--- a/Libraries/MiKTeX/Core/include/miktex/Core/hash_icase.h
+++ b/Libraries/MiKTeX/Core/include/miktex/Core/hash_icase.h
@@ -40,7 +40,7 @@ public:
   std::size_t operator() (const std::string& str) const
   {
     // see http://www.isthe.com/chongo/tech/comp/fnv/index.html
-#if defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
+#if defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(__aarch64__)
     MIKTEX_ASSERT(sizeof(std::size_t) == 8);
     const std::size_t FNV_prime = 1099511628211ULL;
     const std::size_t offset_basis = 14695981039346656037ULL;

--- a/Libraries/MiKTeX/Util/PathName/PathName.cpp
+++ b/Libraries/MiKTeX/Util/PathName/PathName.cpp
@@ -401,7 +401,7 @@ PathName& PathName::CutOffLastComponent(bool allowSelfCutting)
 size_t PathName::GetHash() const
 {
   // see http://www.isthe.com/chongo/tech/comp/fnv/index.html
-#if defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
+#if defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(__arch64__)
   const size_t FNV_prime = 1099511628211;
   const size_t offset_basis = 14695981039346656037ull;
 #else


### PR DESCRIPTION
This pr contains:

1. Detect AArch64 target in various files
2. Cherry-pick fix from https://github.com/freedesktop/fontconfig/commit/6def66164a36eed968aae872d76acfac3173d44a.patch?full_index=1 which is also applied by Homebrew: https://github.com/Homebrew/homebrew-core/blob/14b4f7d9f41d1d488c510beea689eceb2162f0f1/Formula/fontconfig.rb#L52-L57

Compilation command:

```shell
brewprefix="`brew --prefix`"
export CMAKE_PREFIX_PATH="${brewprefix}/opt/icu4c:${brewprefix}/opt/openssl:${brewprefix}/opt/icu4c:${brewprefix}/opt/qt:${CMAKE_PREFIX_PATH}"
cmake .. -DMIKTEX_RELEASE_STATE=4
```

In Big Sur on Apple Silicon, ad-hoc signature is required. Ad-hoc signature fix is required for dylibs and Qt framework libraries even for development:

```shell
#!/bin/bash
for file in /Applications/MiKTeX\ Console.app/Contents/*/*.dylib /Applications/MiKTeX\ Console.app/Contents/*/*/*.dylib /Applications/MiKTeX\ Console.app/Contents/Frameworks/Qt*/Versions/*/Qt*
do
	mv "$file" "$file.bak"
	cp "$file.bak" "$file"
	codesign --force -s - -vvv "$file"
	rm "$file.bak"
done
```

I am able to use MiKTeX on Apple M1:

```
/Applications/MiKTeX Console.app/Contents/MacOS/MiKTeX Console: Mach-O 64-bit executable arm64
```

By the way, it seems that MiKTeX lacks CI? There are obvious compilation problems for debug builds.