### PR TITLE
Convert Windows filepaths to lowercase and backslashes in mthelp

### DIFF
--- a/Programs/MiKTeX/mthelp/mthelp.cpp
+++ b/Programs/MiKTeX/mthelp/mthelp.cpp
@@ -313,6 +313,13 @@ void MiKTeXHelp::ViewFile(const PathName& fileName)
 #if defined(MIKTEX_WINDOWS)
   if (viewer.empty())
   {
+    // convert path to lowercase with backslashes to accommodate Windows programs that do not recognize other paths
+    string win32FileName = fileName.ToString();
+    std::transform(win32FileName.begin(), win32FileName.end(), win32FileName.begin(), [](char c) {
+      return std::tolower(c);
+    });
+    std::replace(win32FileName.begin(), win32FileName.end(), '/', '\\');
+
     wchar_t szExecutable[BufferSizes::MaxPath];
     HINSTANCE hInst = FindExecutableW(fileName.ToWideCharString().c_str(), L"C:\\", szExecutable);
     if (hInst >= reinterpret_cast<HINSTANCE>(32))
@@ -320,11 +327,11 @@ void MiKTeXHelp::ViewFile(const PathName& fileName)
       viewer = StringUtil::WideCharToUTF8(szExecutable);
       if (printOnly)
       {
-        cout << Q_(PathName(szExecutable)) << ' ' << Q_(fileName) << endl;
+        cout << Q_(PathName(szExecutable)) << ' ' << Q_(win32FileName) << endl;
       }
       else
       {
-        Process::Start(PathName(szExecutable), { PathName(szExecutable).GetFileNameWithoutExtension().ToString(), fileName.ToString() });
+        Process::Start(PathName(szExecutable), { PathName(szExecutable).GetFileNameWithoutExtension().ToString(), win32FileName });
       }
       return;
     }


### PR DESCRIPTION
This attempts to resolve an issue where `mthelp` (and its `texdoc` shim in MiKTeX) would generate incorrect Windows file paths due to forward/back slash quirks. If it works on your end, this should close https://github.com/MiKTeX/miktex/issues/1349, close https://github.com/MiKTeX/miktex/issues/637, and properly resolve https://github.com/MiKTeX/miktex/issues/551 (as well as any other duplicates).

I do not have a Windows development environment, but the relevant portions of code appear to compile and run correctly on my Linux machine when taken out of the `#if defined(MIKTEX_WINDOWS)` block.