### PR TITLE
fmt/core.h: undef'ing PACKED to avoid error on macOS

### DIFF
--- a/Libraries/3rd/fmt/source/include/fmt/core.h
+++ b/Libraries/3rd/fmt/source/include/fmt/core.h
@@ -1554,6 +1554,8 @@ constexpr auto encode_types() -> unsigned long long {
 template <typename T, typename Char> struct type_is_unformattable_for;
 #endif
 
+#undef PACKED
+
 template <bool PACKED, typename Context, typename T, FMT_ENABLE_IF(PACKED)>
 FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
   using arg_type = remove_cvref_t<decltype(arg_mapper<Context>().map(val))>;


### PR DESCRIPTION
When compiling on macOS, PACKED has a macro definition which breaks the template.

```[  5%] Building CXX object Libraries/3rd/harfbuzz/shared/CMakeFiles/miktex-harfbuzz.dir/__/source/src/hb-ot-cff2-table.cc.o
In file included from miktex/BuildUtilities/c4p/gram.y:20:
In file included from miktex/Libraries/3rd/fmt/source/include/fmt/format.h:49:
miktex/Libraries/3rd/fmt/source/include/fmt/core.h:1557:16: error: expected ',' or '>' in template-parameter-list
template <bool PACKED, typename Context, typename T, FMT_ENABLE_IF(PACKED)>
               ^
miktex/cmake-build/BuildUtilities/c4p/gram.cpp:158:16: note: expanded from macro 'PACKED'
#define PACKED 281
               ^
In file included from miktex/BuildUtilities/c4p/gram.y:20:
In file included from miktex/Libraries/3rd/fmt/source/include/fmt/format.h:49:
miktex/Libraries/3rd/fmt/source/include/fmt/core.h:1557:22: error: expected unqualified-id
template <bool PACKED, typename Context, typename T, FMT_ENABLE_IF(PACKED)>
                     ^
miktex/Libraries/3rd/fmt/source/include/fmt/core.h:1609:37: error: friend declaration of 'make_arg' does not match any declaration in namespace 'fmt::detail'
  friend FMT_CONSTEXPR auto detail::make_arg(T& value)
                                    ^~~~~~~~
miktex/Libraries/3rd/fmt/source/include/fmt/core.h:1808:23: error: no member named 'make_arg' in namespace 'fmt::detail'
        data_{detail::make_arg<is_packed, Context>(args)...} {
              ~~~~~~~~^
miktex/Libraries/3rd/fmt/source/include/fmt/core.h:1808:43: error: 'Context' does not refer to a value
        data_{detail::make_arg<is_packed, Context>(args)...} {
                                          ^
miktex/Libraries/3rd/fmt/source/include/fmt/core.h:1773:20: note: declared here
template <typename Context, typename... Args>
                   ^
In file included from miktex/BuildUtilities/c4p/gram.y:20:
miktex/Libraries/3rd/fmt/source/include/fmt/format.h:1086:39: error: no member named 'make_arg' in namespace 'fmt::detail'
  loc_value(T value) : value_(detail::make_arg<format_context>(value)) {}
                              ~~~~~~~~^
miktex/Libraries/3rd/fmt/source/include/fmt/format.h:1086:48: error: unexpected type name 'format_context': expected expression
  loc_value(T value) : value_(detail::make_arg<format_context>(value)) {}
                                               ^
[  5%] Building CXX object Libraries/3rd/harfbuzz/shared/CMakeFiles/miktex-harfbuzz.dir/__/source/src/hb-ot-color.cc.o```

By undef'ing it, the error is mitigated. 