### PR TITLE
libf2c/err.c: #include <unistd.h> missing, doesn't compile on macOS

### DIFF
--- a/Programs/Preprocessors/pmx/source/libf2c/err.c
+++ b/Programs/Preprocessors/pmx/source/libf2c/err.c
@@ -1,5 +1,8 @@
 #include "sysdep1.h"	/* here to get stat64 on some badly designed Linux systems */
 #include "f2c.h"
+#ifdef HAVE_UNISTD_H
+#include <unistd.h> /* for isatty() */
+#endif
 #ifdef KR_headers
 extern char *malloc();
 #else


### PR DESCRIPTION
Include is correct in `fio.h`, so the import is just copied from there: https://github.com/MiKTeX/miktex/blob/e56735dce0796d43f9d6372f190f8599ebfb53e8/Programs/Preprocessors/pmx/source/libf2c/fio.h#L6-8

```c
#ifdef HAVE_UNISTD_H
#include <unistd.h> /* for isatty() */
#endif
```