### PR TITLE
replace memcpy in GenericCopyString with memmove

### DIFF
--- a/Libraries/MiKTeX/Util/StringUtil.cpp
+++ b/Libraries/MiKTeX/Util/StringUtil.cpp
@@ -102,7 +102,7 @@ template<typename CharType> size_t GenericCopyString(CharType* lpszBuf, size_t b
         FATAL_ERROR();
     }
 
-    memcpy(lpszBuf, lpszSource, sizeof(CharType) * (length + 1));
+    memmove(lpszBuf, lpszSource, sizeof(CharType) * (length + 1));
 
     return length;
 }


### PR DESCRIPTION
GenericCopyString is sometimes called with two equal pointers, which is undefined behavior with memcpy and can trigger hardening traps