### PR TITLE
Additional encoding argument for none x86 systems

### DIFF
--- a/BuildUtilities/c4p/CMakeLists.txt
+++ b/BuildUtilities/c4p/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 set(MIKTEX_CURRENT_FOLDER "${MIKTEX_IDE_BUILD_UTILITIES_FOLDER}")
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le|aarch64")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
+endif ()
+
 include_directories(BEFORE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/Programs/TeXAndFriends/Knuth/web/CMakeLists.txt
+++ b/Programs/TeXAndFriends/Knuth/web/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 set(MIKTEX_CURRENT_FOLDER "${MIKTEX_IDE_KNUTH_FOLDER}/web")
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le|aarch64")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
+endif ()
+
 include_directories(BEFORE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Hi,

regarding issue #1440, this change allows compiling MiKTeX on none x86 architectures, for example ARM64. All credits to @sumitd2. I just formed his solution into a PR.

The list is defined within this Regex: `"^(powerpc|ppc)64le|aarch64"`

Since ARM CPUs are rising, and more diverse than good old x86, this list will most probably grow.

The list currently contains following architectures:

- powerpc64le
- ppc64le
- aarch64