### PR TITLE
Fix typo in uninstall message

### DIFF
--- a/Programs/MiKTeX/Console/Qt/mainwindow.cpp
+++ b/Programs/MiKTeX/Console/Qt/mainwindow.cpp
@@ -2659,7 +2659,7 @@ bool FactoryResetWorker::Run()
 void MainWindow::FactoryReset()
 {
   QString message = tr("<h3>Reset the TeX installation to factory defaults</h3>");
-  message += tr("<p>You are about to reset your TeX installation. All TEXMF root directories will be removed and you will loose all configuration settings, log files, data files and packages.");
+  message += tr("<p>You are about to reset your TeX installation. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.");
   message += tr(" In other words: your TeX installation will be restored to its original state, as when it was first installed.</p>");
   message += tr("Are you sure?");
   if (QMessageBox::warning(this, TheNameOfTheGame, message, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
@@ -2737,7 +2737,7 @@ bool UninstallWorker::Run()
 void MainWindow::Uninstall()
 {
   QString message = tr("<h3>Remove MiKTeX</h3>");
-  message += tr("<p>You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will loose all configuration settings, log files, data files and packages.</p>");
+  message += tr("<p>You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.</p>");
   message += tr("Are you sure?");
   if (QMessageBox::warning(this, TheNameOfTheGame, message, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
   {

--- a/Programs/MiKTeX/Console/Qt/translations/console_de.ts
+++ b/Programs/MiKTeX/Console/Qt/translations/console_de.ts
@@ -1290,7 +1290,7 @@ The application window will now be closed.</source>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2649"/>
-        <source>&lt;p&gt;You are about to reset your TeX installation. All TEXMF root directories will be removed and you will loose all configuration settings, log files, data files and packages.</source>
+        <source>&lt;p&gt;You are about to reset your TeX installation. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.</source>
         <translation>&lt;p&gt;Sie sind im Begriff, die TeX-Installation auf Werkseinstellungen zurückzusetzen. Alle TEXMF-Wurzelverzeichnisse werden entfernt und Sie verlieren alle Konfigurationseinstellungen, Log-Dateien, Datendateien und Pakete.</translation>
     </message>
     <message>
@@ -1330,7 +1330,7 @@ Das Anwendungsfenster wird jetzt geschlossen.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2727"/>
-        <source>&lt;p&gt;You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will loose all configuration settings, log files, data files and packages.&lt;/p&gt;</source>
+        <source>&lt;p&gt;You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Sie sind im Begriff, MiKTeX von Ihrem Computer zu entfernen. Alle TEXMF-Wurzelverzeichnisse werden entfernt und sie verlieren alle Konfigurationseinstellungen, Log-Dateien, Datendateien und Pakete.&lt;/p&gt;</translation>
     </message>
     <message>

--- a/Programs/MiKTeX/Console/Qt/translations/console_zh_CN.ts
+++ b/Programs/MiKTeX/Console/Qt/translations/console_zh_CN.ts
@@ -1293,7 +1293,7 @@ The application window will now be closed.</source>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2649"/>
-        <source>&lt;p&gt;You are about to reset your TeX installation. All TEXMF root directories will be removed and you will loose all configuration settings, log files, data files and packages.</source>
+        <source>&lt;p&gt;You are about to reset your TeX installation. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.</source>
         <translation type="unfinished">&lt;p&gt;您即将重置您的 TeX 安装。所有的 TEXMF 根目录将被删除，您将失去所有的配置设置、日志文件、数据文件以及宏包。</translation>
     </message>
     <message>
@@ -1333,7 +1333,7 @@ The application window will now be closed.</source>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2727"/>
-        <source>&lt;p&gt;You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will loose all configuration settings, log files, data files and packages.&lt;/p&gt;</source>
+        <source>&lt;p&gt;You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.&lt;/p&gt;</source>
         <translation type="unfinished">&lt;p&gt;您即将从您的计算机删除 MikTeX。所有的 TEXMF 根目录将被删除，您将失去所有的配置设置、日志文件、数据文件以及宏包。&lt;/p&gt;</translation>
     </message>
     <message>


### PR DESCRIPTION
![miktex_typo](https://github.com/user-attachments/assets/8c1f7ac9-3e06-41c0-b470-37b3e80b6b18)
