### PR TITLE
Disable blocking dialog when restarting in admin mode #1643

### DIFF
--- a/Programs/MiKTeX/Console/Qt/mainwindow.cpp
+++ b/Programs/MiKTeX/Console/Qt/mainwindow.cpp
@@ -235,7 +235,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
       return;
     }
   }
-  if (updateModel->Pending() > 0)
+  if (updateModel->Pending() > 0 && !restartingToApplyUpdates)
   {
     if (QMessageBox::question(this, TheNameOfTheGame, tr("There are pending updates. Are you sure you want to quit %1?").arg(TheNameOfTheGame))
       != QMessageBox::Yes)
@@ -657,6 +657,7 @@ void MainWindow::RestartAdmin()
       {
         return;
       }
+      restartingToApplyUpdates = true;
     }
     RestartAdminWithArguments({ "--admin" });
   }

--- a/Programs/MiKTeX/Console/Qt/mainwindow.h
+++ b/Programs/MiKTeX/Console/Qt/mainwindow.h
@@ -247,6 +247,9 @@ private slots:
 private slots:
   void AboutDialog();
 
+private:
+  bool restartingToApplyUpdates = false;
+
 private slots:
   void RestartAdmin();
 


### PR DESCRIPTION
This PR aims to solve my issue #1643 by making sure the confirmation dialog for quitting does not appear twice, thus blocking startup of the second instance. 