### PR TITLE
hitex: check USE_SYSTEM_HARFBUZZ_ICU

### DIFF
--- a/Programs/TeXAndFriends/hitex/CMakeLists.txt
+++ b/Programs/TeXAndFriends/hitex/CMakeLists.txt
@@ -124,7 +124,6 @@ set_property(TARGET ${MIKTEX_PREFIX}hitex PROPERTY FOLDER ${MIKTEX_CURRENT_FOLDE
 target_link_libraries(${MIKTEX_PREFIX}hitex
     ${app_dll_name}
     ${core_dll_name}
-    ${harfbuzz_dll_name}
     ${kpsemu_dll_name}
     ${w2cemu_dll_name}
 )
@@ -139,6 +138,13 @@ if(USE_SYSTEM_ZLIB)
     target_link_libraries(${MIKTEX_PREFIX}hitex MiKTeX::Imported::ZLIB)
 else()
     target_link_libraries(${MIKTEX_PREFIX}hitex ${zlib_dll_name})
+endif()
+
+if(USE_SYSTEM_HARFBUZZ_ICU)
+    target_link_libraries(${MIKTEX_PREFIX}hitex MiKTeX::Imported::HARFBUZZ_ICU)
+    target_link_libraries(${MIKTEX_PREFIX}hitex MiKTeX::Imported::HARFBUZZ)
+else()
+    target_link_libraries(${MIKTEX_PREFIX}hitex ${harfbuzz_dll_name})
 endif()
 
 if(MIKTEX_NATIVE_WINDOWS)


### PR DESCRIPTION
This should fix build of hitex with system harfbuzz on linux.