### PR TITLE
find exectables in path

### DIFF
--- a/Libraries/MiKTeX/Core/Session/filetypes.cpp
+++ b/Libraries/MiKTeX/Core/Session/filetypes.cpp
@@ -198,6 +198,15 @@ void SessionImpl::RegisterFileType(FileType fileType)
       searchPath.push_back(myPrefixBinCanon.ToString());
     }
 #endif
+    if (Utils::GetEnvironmentString("PATH", str))
+    {
+      PathName binDir(str);
+      binDir.Canonicalize();
+      if (std::find(searchPath.begin(), searchPath.end(), binDir.ToString()) == searchPath.end())
+      {
+        searchPath.push_back(binDir.ToString());
+      }
+    }
     break;
   }
   case FileType::OTF:


### PR DESCRIPTION
Miktex will search exectables in "GetMyPrefix(true)/bin"
The path evaluate to "/usr/bin" in FHS style linux distribution,
compared to "/nix/store/.../bin" in NixOS.
As a result, miktex will fail to find e.g. 'pkexec','ksudo','gksu'
under /run/wrappers/bin in NixOS.
We fix this by adding the PATH environment variable to exectables' search path.