### PR TITLE
fprintf: avoid format string by using %s

### DIFF
--- a/Programs/TeXAndFriends/omega/otps/source/outocp.c
+++ b/Programs/TeXAndFriends/omega/otps/source/outocp.c
@@ -90,7 +90,7 @@ char *otp_names[] = {
 void
 ctp_abort P1C(string, s)
 {
-  fprintf(stderr, s);
+  fprintf(stderr, "%s", s);
   exit(EXIT_FAILURE);
 }
  


### PR DESCRIPTION
otherwise compiler will warn format-security