### PR TITLE
Fix Y2K38 bug in PackageManagerImpl

### DIFF
--- a/Libraries/MiKTeX/PackageManager/PackageManagerImpl.cpp
+++ b/Libraries/MiKTeX/PackageManager/PackageManagerImpl.cpp
@@ -1212,21 +1212,21 @@ InstallationSummary PackageManagerImpl::GetInstallationSummary(bool userScope)
         userScope ? MIKTEX_CONFIG_VALUE_LAST_USER_UPDATE_CHECK : MIKTEX_CONFIG_VALUE_LAST_ADMIN_UPDATE_CHECK,
         lastUpdateCheckText))
     {
-        result.lastUpdateCheck = std::stol(lastUpdateCheckText);
+        result.lastUpdateCheck = std::stoll(lastUpdateCheckText);
     }
     string lastUpdateText;
     if (session->TryGetConfigValue(MIKTEX_CONFIG_SECTION_MPM,
         userScope ? MIKTEX_CONFIG_VALUE_LAST_USER_UPDATE : MIKTEX_CONFIG_VALUE_LAST_ADMIN_UPDATE,
         lastUpdateText))
     {
-        result.lastUpdate = std::stol(lastUpdateText);
+        result.lastUpdate = std::stoll(lastUpdateText);
     }
     string lastUpdateDbText;
     if (session->TryGetConfigValue(MIKTEX_CONFIG_SECTION_MPM,
         userScope ? MIKTEX_CONFIG_VALUE_LAST_USER_UPDATE_DB : MIKTEX_CONFIG_VALUE_LAST_ADMIN_UPDATE_DB,
         lastUpdateDbText))
     {
-        result.lastUpdateDb = std::stol(lastUpdateDbText);
+        result.lastUpdateDb = std::stoll(lastUpdateDbText);
     }
     return result;
 }


### PR DESCRIPTION
- ``std::stol`` returns a long: The C++ standard defines std::stol to return a long int.
- long is 32-bit on Windows: Unlike Linux/macOS (where long is 64-bit), Microsoft Visual C++ defines long as a 32-bit signed integer, even in 64-bit build
- https://learn.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=msvc-180