### PR TITLE
Add Russian translations for MiKTeX

### DIFF
--- a/Libraries/MiKTeX/App/po/ru/miktex-app.po
+++ b/Libraries/MiKTeX/App/po/ru/miktex-app.po
@@ -1,0 +1,83 @@
+# Russian translations for MiKTeX package.
+# Copyright (C) 2021 THE MiKTeX'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the MiKTeX package.
+# Christian Schenk <cs@miktex.org>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MiKTeX 21.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-01-15 14:55+0100\n"
+"PO-Revision-Date: 2026-02-18 10:13+0300\n"
+"Last-Translator: Christian Schenk <cs@miktex.org>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: app.cpp:148 app.cpp:156
+msgid "The current operation has been cancelled (Ctrl-C)."
+msgstr "Операция была отменена (Ctrl-C)."
+
+#: app.cpp:528 app.cpp:524 app.cpp:525
+msgid "running with elevated privileges"
+msgstr "выполняется с расширенными привилегиями"
+
+#: app.cpp:783 app.cpp:779 app.cpp:781
+msgid "The MiKTeX configuration utility (initexmf) could not be found."
+msgstr "Не удалось найти инструмент настройки MiKTeX (initexmf)."
+
+#: app.cpp:794 app.cpp:790 app.cpp:792
+msgid "The MakeTFM utility could not be found."
+msgstr "Не удалось найти инструмент MakeTFM."
+
+#: app.cpp:898 app.cpp:894 app.cpp:896
+msgid "Sorry, but {0} did not succeed."
+msgstr "Извините, но {0} не удалось выполнить."
+
+#: app.cpp:903 app.cpp:899 app.cpp:901
+msgid "Sorry, but {0} did not succeed for the following reason:"
+msgstr "Извините, но {0} не удалось выполнить по следующей причине:"
+
+#: app.cpp:910 app.cpp:906 app.cpp:908
+msgid "Remedy:"
+msgstr "Устранение:"
+
+#: app.cpp:933 app.cpp:929 app.cpp:317 app.cpp:318 app.cpp:931
+msgid "For more information, visit:"
+msgstr "Для получения дополнительной информации посетите:"
+
+#: app.cpp:984 app.cpp:980 app.cpp:982
+msgid "warning"
+msgstr "предупреждение"
+
+#: app.cpp:990 app.cpp:993 app.cpp:986 app.cpp:989 app.cpp:988 app.cpp:991
+msgid "security risk"
+msgstr "угроза безопасности"
+
+#: app.cpp:315 app.cpp:316
+msgid "It seems that this is a fresh TeX installation."
+msgstr "Похоже, это новая установка TeX."
+
+#: app.cpp:316 app.cpp:317
+msgid "Please finish the setup before proceeding."
+msgstr "Пожалуйста, завершите настройку, прежде чем продолжить."
+
+#: app.cpp:733 app.cpp:735
+msgid "Unfortunately, the package {0} could not be installed."
+msgstr "К сожалению, пакет {0} не может быть установлен."
+
+#: app.cpp:738 app.cpp:740
+msgid "Please check the log file:"
+msgstr "Пожалуйста, проверьте файл журнала:"
+
+#: app.cpp:919 app.cpp:921
+msgid ""
+"The log file hopefully contains the information to get MiKTeX going again:"
+msgstr ""
+"Надеемся, что файл журнала содержит всю информацию, необходимую для "
+"возобновления работы MiKTeX:"

--- a/Libraries/MiKTeX/Setup/po/ru/miktex-setup.po
+++ b/Libraries/MiKTeX/Setup/po/ru/miktex-setup.po
@@ -1,0 +1,108 @@
+# Russian translations for MiKTeX package.
+# Copyright (C) 2021 THE MiKTeX'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the MiKTeX package.
+# Christian Schenk <cs@miktex.org>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MiKTeX 20.12\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-12-27 19:14+0100\n"
+"PO-Revision-Date: 2026-02-19 12:53+0300\n"
+"Last-Translator: Christian Schenk <cs@miktex.org>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: SetupService.cpp:1960
+msgid "The PATH variable does not include the MiKTeX executables."
+msgstr "Исполняемые файлы MiKTeX не добавлены в переменную PATH."
+
+#: SetupService.cpp:1961
+msgid ""
+"Find the directory which contains the MiKTeX executables and add it to the "
+"environment variable PATH."
+msgstr ""
+"Найдите каталог, содержащий исполняемые файлы MiKTeX, и добавьте его в "
+"переменную среды PATH."
+
+#: SetupService.cpp:1976 SetupService.cpp:2008
+msgid "So far, no MiKTeX administrator has checked for updates."
+msgstr ""
+"До сих пор ни один администратор MiKTeX не проверял наличие обновлений."
+
+#: SetupService.cpp:1977 SetupService.cpp:1986 SetupService.cpp:1999
+#: SetupService.cpp:2009 SetupService.cpp:2018
+msgid "Switch to MiKTeX administrator mode and check for updates."
+msgstr ""
+"Перейдите в режим администратора MiKTeX и проверьте наличие обновлений."
+
+#: SetupService.cpp:1985 SetupService.cpp:2017
+msgid ""
+"It has been a long time since a MiKTeX administrator has checked for updates."
+msgstr ""
+"Прошло много времени с тех пор, как администратор MiKTeX проверял наличие "
+"обновлений."
+
+#: SetupService.cpp:1998 SetupService.cpp:2037
+msgid "User/administrator updates are out-of-sync."
+msgstr "Обновления пользователя / администратора не синхронизированы."
+
+#: SetupService.cpp:2028
+msgid "So far, you have not checked for updates as a MiKTeX user."
+msgstr ""
+"До сих пор вы, как пользователь MiKTeX, еще не проверяли наличие обновлений."
+
+#: SetupService.cpp:2029 SetupService.cpp:2038 SetupService.cpp:2048
+msgid "Stay in MiKTeX user mode and check for updates."
+msgstr "Проверьте наличие обновлений в режиме пользователя MiKTeX."
+
+#: SetupService.cpp:2047
+msgid ""
+"It has been a long time since you have checked for updates as a MiKTeX user."
+msgstr ""
+"Прошло много времени с тех пор, как вы, пользователь MiKTeX, проверяли "
+"наличие обновлений."
+
+#: SetupService.cpp:2064
+msgid "So far, you have not checked for MiKTeX updates."
+msgstr "До сих пор вы не проверяли наличие обновлений MiKTeX."
+
+#: SetupService.cpp:2065 SetupService.cpp:2074
+msgid "Check for MiKTeX updates."
+msgstr "Проверить наличие обновлений MiKTeX."
+
+#: SetupService.cpp:2073
+msgid "It has been a long time since you have checked for MiKTeX updates."
+msgstr ""
+"Прошло много времени с тех пор, как вы проверяли наличие обновлений MiKTeX."
+
+#: SetupService.cpp:2088
+msgid "Root directory #{0} is covered by root directory #{1}."
+msgstr "Корневой каталог #{0} перекрывается корневым каталогом #{1}."
+
+#: SetupService.cpp:2097
+msgid "Root directory #{0} covers root directory #{1}."
+msgstr "Корневой каталог #{0} перекрывает корневой каталог #{1}."
+
+#: SetupService.cpp:2118
+msgid "Package {0} has been tampered with."
+msgstr "Пакет {0} был взломан."
+
+#: win/winSetupService.cpp:145
+msgid "MiKTeX Console helps you to manage your MiKTeX configuration."
+msgstr "Консоль MiKTeX поможет вам управлять конфигурацией MiKTeX."
+
+#: win/winSetupService.cpp:162
+msgid "TeXworks is a TeX front-end program."
+msgstr "TeXworks - это интерфейс для TeX."
+
+#: win/winSetupService.cpp:637
+msgid "MiKTeX is a scalable TeX distribution for Windows, Linux and macOS."
+msgstr ""
+"MiKTeX - это масштабируемый дистрибутив TeX для Windows, Linux и macOS."

--- a/Libraries/MiKTeX/TeXAndFriends/po/ru/miktex-texmf.po
+++ b/Libraries/MiKTeX/TeXAndFriends/po/ru/miktex-texmf.po
@@ -1,0 +1,267 @@
+# Russian translations for MiKTeX package.
+# Copyright (C) 2021 THE MiKTeX'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the MiKTeX package.
+# Christian Schenk <cs@miktex.org>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MiKTeX 20.12\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-01-05 16:10+0100\n"
+"PO-Revision-Date: 2026-02-24 10:07+0300\n"
+"Last-Translator: Danil Kostenkov <danilkostenkov38@gmail.com>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: etexapp.cpp:85
+msgid "Enable e-TeX extensions."
+msgstr "Включить расширения e-TeX."
+
+#: mfapp.cpp:79 mfapp.cpp:80 mfapp.cpp:81 texapp.cpp:145 texapp.cpp:150 texapp.cpp:160
+#: texapp.cpp:168 texapp.cpp:190 texapp.cpp:197 texapp.cpp:201 texmfapp.cpp:287
+#: texmfapp.cpp:290 texmfapp.cpp:294 texmfapp.cpp:299 texmfapp.cpp:302 texmfapp.cpp:313
+#: texmfapp.cpp:314 texmfapp.cpp:315 texmfapp.cpp:318 texmfapp.cpp:323 texmfapp.cpp:326
+#: texmfapp.cpp:329 texmfapp.cpp:332
+msgid "Set {0} to N."
+msgstr "Установить значение N для {0}."
+
+#: texapp.cpp:136
+msgid "Disable the \\write18{COMMAND} construct."
+msgstr "Отключить конструкцию \\write18{COMMAND}."
+
+#: texapp.cpp:139
+msgid "Enable MLTeX extensions such as \\charsubdef."
+msgstr "Включить расширения MLTeX, такие как \\charsubdef."
+
+#: texapp.cpp:142
+msgid "Enable the \\write18{COMMAND} construct."
+msgstr "Включить конструкцию \\write18{COMMAND}."
+
+#: texapp.cpp:155
+msgid "Set mem_bot to 0 or 1."
+msgstr "Установить значение 0 или 1 для параметра mem_bot."
+
+#: texapp.cpp:165
+msgid "Partially enable the \\write18{COMMAND} construct."
+msgstr "Частично включить конструкцию \\write18{COMMAND}."
+
+#: texapp.cpp:175
+msgid "Enable EncTeX extensions such as \\mubyte."
+msgstr "Включить расширения EncTeX, такие как \\mubyte."
+
+#: texapp.cpp:182
+msgid "Generate SyncTeX data for previewers if nonzero."
+msgstr ""
+"Генерировать данные SyncTeX для программ предварительного просмотра, если значение "
+"отличается от 0."
+
+#: texapp.cpp:208
+msgid ""
+"Insert source specials in certain places of the DVI file.  WHERE is a comma-separated "
+"value list of: cr display hbox math par parend vbox."
+msgstr "Вставить специальные ссылки на исходный код в определённые места в файле DVI."
+
+#: texapp.cpp:213
+msgid "Insert source specials in certain places of the DVI file."
+msgstr "Вставить специальные ссылки на исходный код в определённые места в файле DVI."
+
+#: texapp.cpp:342
+msgid "Unknown source special."
+msgstr "Не определённая специальная ссылка."
+
+#: texmfapp.cpp:282
+msgid "Make all characters printable by default."
+msgstr "Сделать все символы доступными для печати по умолчанию."
+
+#: texmfapp.cpp:283
+msgid "Make only 7-bit characters printable."
+msgstr "Сделать доступными для печати только 7-битные символы."
+
+#: texmfapp.cpp:286
+msgid "Use DIR as the directory to write auxiliary files to."
+msgstr ""
+"Использовать DIR в качестве каталога, в который записываются вспомогательные файлы."
+
+#: texmfapp.cpp:288
+msgid "Enable file:line:error style messages."
+msgstr "Включить сообщения типа Файл:Строка:Ошибка."
+
+#: texmfapp.cpp:289
+msgid ""
+"Do not parse the first line of the input line to look for a dump name and/or extra "
+"command-line options."
+msgstr ""
+"Игнорировать первую строку входного файла, чтобы найти имя дампа и/или дополнительные "
+"параметры командной строки."
+
+#: texmfapp.cpp:303
+msgid "Stop after the first error."
+msgstr "Останавливаться после первой ошибки."
+
+#: texmfapp.cpp:307
+msgid "Be the INI variant of the program."
+msgstr "INI-вариант программы."
+
+#: texmfapp.cpp:310
+msgid ""
+"Set the interaction mode; MODE ist einer der folgenden Werte: batchmode, nonstopmode, "
+"scrollmode, errorstopmode."
+msgstr ""
+"Установить режим взаимодействия. РЕЖИМ - это одно из следующих значений: пакетный "
+"режим, режим без остановок, режим прокрутки, режим ошибки."
+
+#: texmfapp.cpp:311
+msgid "Set the job name and hence the name(s) of the output file(s)."
+msgstr "Установить название задания и, следовательно, имя выходного файла."
+
+#: texmfapp.cpp:312
+msgid "Set the job time.  Take FILE's timestamp as the reference."
+msgstr "Установить время задачи.  Возьмите временную метку FILE в качестве ссылки."
+
+#: texmfapp.cpp:316
+msgid "Disable file:line:error style messages."
+msgstr "Отключить сообщения типа Файл:Строка:Ошибка."
+
+#: texmfapp.cpp:317
+msgid "Use DIR as the directory to write output files to."
+msgstr "Использовать DIR в качестве каталога для записи выходных файлов."
+
+#: texmfapp.cpp:319
+msgid ""
+"Parse the first line of the input line to look for a dump name and/or extra command-"
+"line options."
+msgstr ""
+"Просматривать первую строку входного файла, чтобы найти имя дампа и/или дополнительные "
+"параметры командной строки."
+
+#: texmfapp.cpp:327
+msgid "Suppress all output (except errors)."
+msgstr "Скрыть все выходные данные (кроме ошибок)."
+
+#: texmfapp.cpp:328
+msgid ""
+"Turn on the file name recorder to leave a trace of the files opened for input and "
+"output in a file with extension .fls."
+msgstr ""
+"Включите функцию записи имён файлов, чтобы  записывать открытые входные и выходные "
+"файлы в файл с расширением .fls."
+
+#: texmfapp.cpp:330
+msgid "Disable MiKTeX extensions."
+msgstr "Отключить расширения MiKTeX."
+
+#: texmfapp.cpp:333
+msgid "Show processing time statistics."
+msgstr "Показать статистику времени выполнения."
+
+#: texmfapp.cpp:334
+msgid "Use NAME instead of program name when loading internal tables."
+msgstr "Используйте NAME вместо имени программы при загрузке внутренних таблиц."
+
+#: texmfapp.cpp:338
+msgid ""
+"Use the TCXNAME translation table to set the mapping of input characters and re-mapping "
+"of output characters."
+msgstr ""
+"Используйте таблицу перевода TCXNAME, чтобы задать назначение входных символов и "
+"переназначение выходных символов."
+
+#: texmfapp.cpp:402
+msgid "The specified auxiliary directory does not exist."
+msgstr "Указанный вспомогательный каталог не существует."
+
+#: texmfapp.cpp:464
+msgid "Invalid interaction mode."
+msgstr "Недопустимый режим взаимодействия."
+
+#: texmfapp.cpp:483
+msgid "Missing timestamp."
+msgstr "Отсутствует временная метка."
+
+#: texmfapp.cpp:536
+msgid "The specified output directory does not exist."
+msgstr "Указанный выходной каталог не существует."
+
+#: texmfapp.cpp:717
+msgid "The memory dump file could not be found."
+msgstr "Не удалось найти файл дампа памяти."
+
+#: texmflib.cpp:80
+msgid "The font file could not be found."
+msgstr "Не удалось найти файл шрифта."
+
+#: webapp.cpp:205
+msgid "Invalid command-line. Try this:\n"
+msgstr "Недопустимый аргумент командной строки. Попробуйте следующие варианты:\n"
+
+#: webapp.cpp:263
+msgid "Pretend to be APP.  This affects both the format used and the search path."
+msgstr ""
+"Имитировать приложение.  Это влияет как на используемый формат, так и на путь поиска."
+
+#: webapp.cpp:263
+msgid "APP"
+msgstr "Приложение"
+
+#: webapp.cpp:264
+msgid "Disable the package installer.  Missing files will not be installed."
+msgstr "Отключить установщик пакетов. Отсутствующие файлы не будут установлены."
+
+#: webapp.cpp:265
+msgid "Enable the package installer.  Missing files will be installed."
+msgstr "Включить установщик пакетов. Будут установлены отсутствующие файлы."
+
+#: webapp.cpp:266
+msgid "Show this help screen and exit."
+msgstr "Показать экран справки и выйти."
+
+#: webapp.cpp:267
+msgid "Prefix DIR to the input search path."
+msgstr "Добавлять префикс DIR к входному пути поиска."
+
+#: webapp.cpp:267
+msgid "DIR"
+msgstr "DIR"
+
+#: webapp.cpp:269
+msgid "Enable the package usage recorder.  Output is written to FILE."
+msgstr "Включить запись использования пакетов. Вывод записывается в ФАЙЛ."
+
+#: webapp.cpp:269
+msgid "FILE"
+msgstr "ФАЙЛ"
+
+#: webapp.cpp:270
+msgid ""
+"Turn tracing on.  OPTIONS must be a comma-separated list of trace options.   See the "
+"manual, for more information."
+msgstr ""
+"Включить трассировку.  ПАРАМЕТРЫ должны быть представлены в виде списка параметров "
+"трассировки, разделённых запятыми.   Для получения дополнительной информации обратитесь "
+"к руководству пользователя."
+
+#: webapp.cpp:270
+msgid "OPTIONS"
+msgstr "ПАРАМЕТРЫ"
+
+#: webapp.cpp:271
+msgid "Turn on verbose mode."
+msgstr "Включить подробный режим."
+
+#: webapp.cpp:272
+msgid "Print version information and exit."
+msgstr "Ввести информацию о версии и выйти."
+
+#: webapp.cpp:276
+msgid "Show the manual page in an HTMLHelp window and exit when the window is closed."
+msgstr "Показать страницу руководства в окне HTMLHelp и закрыть ее, когда окно закроется."
+
+#: webapp.cpp:380
+msgid "The command line options could not be processed."
+msgstr "Не удалось обработать параметры командной строки."

--- a/Libraries/MiKTeX/UI/Qt/translations/ui_ru.ts
+++ b/Libraries/MiKTeX/UI/Qt/translations/ui_ru.ts
@@ -1,0 +1,473 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+<context>
+    <name>ConnectionSettingsDialog</name>
+    <message>
+        <location filename="../ConnectionSettingsDialog.ui" line="14"></location>
+        <source>Connection Settings</source>
+        <translation>Настройки подключения</translation>
+    </message>
+    <message>
+        <location filename="../ConnectionSettingsDialog.ui" line="20"></location>
+        <source>&amp;Use a proxy server</source>
+        <translation>&amp;Использовать прокси-сервер</translation>
+    </message>
+    <message>
+        <location filename="../ConnectionSettingsDialog.ui" line="37"></location>
+        <source>&amp;Address:</source>
+        <translation>&amp;Адрес:</translation>
+    </message>
+    <message>
+        <location filename="../ConnectionSettingsDialog.ui" line="57"></location>
+        <source>&amp;Port:</source>
+        <translation>&amp;Порт:</translation>
+    </message>
+    <message>
+        <location filename="../ConnectionSettingsDialog.ui" line="79"></location>
+        <source>Au&amp;thentication required</source>
+        <translation>Требуется ау&amp;тентификация</translation>
+    </message>
+</context>
+<context>
+    <name>ErrorDialog</name>
+    <message>
+        <location filename="../ErrorDialog.ui" line="15"></location>
+        <source>MiKTeX Error Report</source>
+        <translation>Отчёт об ошибке MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../ErrorDialog.ui" line="38"></location>
+        <source>Details:</source>
+        <translation>Подробности:</translation>
+    </message>
+    <message>
+        <location filename="../ErrorDialog.ui" line="52"></location>
+        <source>Copy the error report to the Clipboard.</source>
+        <translation>Скопировать отчёт об ошибке в буфер обмена.</translation>
+    </message>
+    <message>
+        <location filename="../ErrorDialog.ui" line="55"></location>
+        <source>Copy Info</source>
+        <translation>Скопировать отчёт</translation>
+    </message>
+</context>
+<context>
+    <name>ErrorDialogImpl</name>
+    <message>
+        <location filename="../ErrorDialog.cpp" line="97"></location>
+        <source>Report Copied</source>
+        <translation>Отчёт об ошибке скопирован</translation>
+    </message>
+    <message>
+        <location filename="../ErrorDialog.cpp" line="97"></location>
+        <source>The error report has been copied to the Clipboard.</source>
+        <translation>Отчёт об ошибке скопирован в буфер обмена.</translation>
+    </message>
+</context>
+<context>
+    <name>FileTableModel</name>
+    <message>
+        <location filename="../FileTableModel.cpp" line="74"></location>
+        <source>File name</source>
+        <translation>Имя файла</translation>
+    </message>
+    <message>
+        <location filename="../FileTableModel.cpp" line="76"></location>
+        <source>Path</source>
+        <translation>Расположение</translation>
+    </message>
+</context>
+<context>
+    <name>InstallPackageDialog</name>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="24"></location>
+        <source>Package Installation</source>
+        <translation>Установка Пакета</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="30"></location>
+        <source>This required file could not be found:</source>
+        <translation>Не удалось найти требуемый файл:</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="76"></location>
+        <source>The file is a part of this package:</source>
+        <translation>Файл является частью пакета:</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="172"></location>
+        <source>The package will be retrieved from this source:</source>
+        <translation>Пакет получен из источника:</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="193"></location>
+        <source>The location of the package repository. Click Change... to change the location.</source>
+        <translation>Расположение хранилища пакетов. Нажмите Изменить..., чтобы изменить его.</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="225"></location>
+        <source>Change the package repository.</source>
+        <translation>Изменить репозиторий пакетов.</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="228"></location>
+        <source>&amp;Change...</source>
+        <translation>&amp;Изменить...</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="257"></location>
+        <source>The package will be installed for:</source>
+        <translation>Пакет будет установлен из:</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.ui" line="290"></location>
+        <source>&amp;Always show this dialog</source>
+        <translation>&amp;Всегда показывать этот диалог</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.cpp" line="66"></location>
+        <source>Install</source>
+        <translation>Установить</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.cpp" line="78"></location>
+        <source>&lt;Random package repository&gt;</source>
+        <translation>&lt;Любой репозиторий пакетов&gt;</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.cpp" line="86"></location>
+        <source>&lt;All users&gt;</source>
+        <translation>&lt;Все пользователи&gt;</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.cpp" line="100"></location>
+        <source>&lt;Unknown user&gt;</source>
+        <translation>&lt;Неизвестный пользователь&gt;</translation>
+    </message>
+    <message>
+        <location filename="../InstallPackageDialog.cpp" line="115"></location>
+        <source>&lt;Current user&gt;</source>
+        <translation>&lt;Текущий пользователь&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>PackageInfoDialog</name>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="23"></location>
+        <source>Package Information</source>
+        <translation>Информация о пакете</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="33"></location>
+        <source>General</source>
+        <translation>Общее</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="44"></location>
+        <source>Name:</source>
+        <translation>Имя:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="58"></location>
+        <source>Date:</source>
+        <translation>Дата:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="72"></location>
+        <source>Version:</source>
+        <translation>Версия:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="86"></location>
+        <source>Maintainer:</source>
+        <translation>Сопровождающий:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="100"></location>
+        <source>Title:</source>
+        <translation>Название:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="120"></location>
+        <source>Description:</source>
+        <translation>Описание:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="134"></location>
+        <source>Size:</source>
+        <translation>Размер:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="151"></location>
+        <source>Files</source>
+        <translation>Файлы</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="157"></location>
+        <source>Run-time:</source>
+        <translation>Срок действия:</translation>
+    </message>
+    <message>
+        <location filename="../PackageInfoDialog.ui" line="171"></location>
+        <source>Documentation:</source>
+        <translation>Документация:</translation>
+    </message>
+</context>
+<context>
+    <name>ProxyAuthenticationDialog</name>
+    <message>
+        <location filename="../ProxyAuthenticationDialog.ui" line="14"></location>
+        <source>Proxy Authentication</source>
+        <translation>Проверка подлинности по прокси-серверу</translation>
+    </message>
+    <message>
+        <location filename="../ProxyAuthenticationDialog.ui" line="20"></location>
+        <source>Proxy authentication required.</source>
+        <translation>Требуется проверка подлинности по прокси-серверу.</translation>
+    </message>
+    <message>
+        <location filename="../ProxyAuthenticationDialog.ui" line="29"></location>
+        <source>&amp;Name:</source>
+        <translation>&amp;Имя пользователя:</translation>
+    </message>
+    <message>
+        <location filename="../ProxyAuthenticationDialog.ui" line="45"></location>
+        <source>&amp;Password:</source>
+        <translation>&amp;Пароль:</translation>
+    </message>
+</context>
+<context>
+    <name>RepositoryTableModel</name>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="90"></location>
+        <source>Ranking</source>
+        <translation>Ранжирование</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="92"></location>
+        <source>Country</source>
+        <translation>Страна</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="94"></location>
+        <source>Protocol</source>
+        <translation>Протокол</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="96"></location>
+        <source>Host</source>
+        <translation>Хост</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="98"></location>
+        <source>Date</source>
+        <translation>Дата</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="100"></location>
+        <source>Mbit/s</source>
+        <translation>Мбит/с</translation>
+    </message>
+</context>
+<context>
+    <name>SiteWizDrive</name>
+    <message>
+        <location filename="../SiteWizDrive.ui" line="15"></location>
+        <source>MiKTeX CD/DVD</source>
+        <translation>CD/DVD-диск MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizDrive.ui" line="18"></location>
+        <source>Packages will be installed from a MiKTeX CD/DVD.</source>
+        <translation>Пакеты будут установлены с CD/DVD-диска MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizDrive.cpp" line="69"></location>
+        <source>No MiKTeX CD/DVD found</source>
+        <translation>CD/DVD-диск MiKTeX не найден</translation>
+    </message>
+</context>
+<context>
+    <name>SiteWizLocal</name>
+    <message>
+        <location filename="../SiteWizLocal.ui" line="15"></location>
+        <source>Form</source>
+        <translatorcomment>do not translate</translatorcomment>
+        <translation>Форма</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.ui" line="18"></location>
+        <source>Local Package Repository</source>
+        <translation>Локальный репозиторий пакета</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.ui" line="21"></location>
+        <source>A local MiKTeX package repository is a directory on your file system which mirrors a remote package repository.</source>
+        <translation>Локальный репозиторий пакетов MiKTeX — это папка на вашем компьютере, синхронизированная с удалённым репозиторием .</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.ui" line="27"></location>
+        <source>Please choose the directory which contains the repository contents:</source>
+        <translation>Пожалуйста, выберите каталог, содержащий файлы репозитория:</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.ui" line="65"></location>
+        <source>Bro&amp;wse...</source>
+        <translation>Об&amp;зор...</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.ui" line="74"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You do not yet have a local package repository? It is easy to set one up: &lt;a href="https://miktex.org/howto/local-repository"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;HOWTO: set up a local package repository&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;У вас ещё нет локального репозитория пакетов? Его легко настроить: &lt;a href="https://miktex.org/howto/local-repository"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;РУКОВОДСТВО: настройка локального репозитория пакетов&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.cpp" line="85"></location>
+        <source>The specified directory does not exist.</source>
+        <translation>Указанный каталог не существует.</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizLocal.cpp" line="95"></location>
+        <source>Not a local package repository.</source>
+        <translation>Выбранный каталог не является локальным репозиторием пакетов.</translation>
+    </message>
+</context>
+<context>
+    <name>SiteWizRemote</name>
+    <message>
+        <location filename="../SiteWizRemote.ui" line="15"></location>
+        <source>Remote Package Repository</source>
+        <translation>Удалённый репозиторий пакетов</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizRemote.ui" line="18"></location>
+        <source>There are many MiKTeX package repositories around the world.</source>
+        <translation>Во всём мире имеется множество репозиториев пакетов MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizRemote.ui" line="24"></location>
+        <source>For easy selection, the following list is sorted by network proximity. It is recommended that you select a host in your country which supports a secure transport protocol:</source>
+        <translation>Для удобства выбора приведённый ниже список отсортирован по сетевой близости. Рекомендуется выбрать сервер в вашей стране, поддерживающий защищённый протокол передачи данных:</translation>
+    </message>
+</context>
+<context>
+    <name>SiteWizSheetImpl</name>
+    <message>
+        <location filename="../SiteWizSheet.cpp" line="43"></location>
+        <source>Change Package Repository</source>
+        <translation>Изменение репозитория пакетов</translation>
+    </message>
+</context>
+<context>
+    <name>SiteWizType</name>
+    <message>
+        <location filename="../SiteWizType.ui" line="15"></location>
+        <source>Package Source</source>
+        <translation>Источник пакета</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="18"></location>
+        <source>Packages can be retrieved from different sources.</source>
+        <translation>Пакеты могут быть получены из различных источников.</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="24"></location>
+        <source>Please choose the type of package source:</source>
+        <translation>Пожалуйста, выберите тип источника пакета:</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="55"></location>
+        <source>Remote package repository (Internet)</source>
+        <translation>Удалённый репозиторий пакетов (Интернет)</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="78"></location>
+        <source>&amp;Connection Settings...</source>
+        <translation>&amp;Настройки подключения...</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="108"></location>
+        <source>Retrieve pre-release (experimental) packages</source>
+        <translation>Получение предварительных (экспериментальных) версий пакетов</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="117"></location>
+        <source>Local package repository (file system)</source>
+        <translation>Локальный репозиторий пакетов (файловая система)</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="142"></location>
+        <source>&lt;p&gt;You do not yet have a local package repository? It is easy to set one up: &lt;a href="https://miktex.org/howto/local-repository"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;HOWTO: set up a local package repository&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;У вас ещё нет локального репозитория пакетов? Его легко настроить: &lt;a href="https://miktex.org/howto/local-repository"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;РУКОВОДСТВО: настройка локального репозитория пакетов&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.ui" line="157"></location>
+        <source>MiKTeX DVD (mounted drive or ISO image)</source>
+        <translation>DVD-диск MiKTeX (подключённый привод или ISO-образ)</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.cpp" line="149"></location>
+        <source>MiKTeX Package Manager</source>
+        <translation>Менеджер пакетов MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../SiteWizType.cpp" line="150"></location>
+        <source>You have chosen to get untested packages. Although every effort has been made to ensure the correctness of these packages, a hassle-free operation cannot be guaranteed.
+
+Please visit http://miktex.org/kb/miktex-next, for more information.</source>
+        <translation>Вы решили получать непроверенные пакеты. Несмотря на то, что были предприняты все усилия для обеспечения корректности этих пакетов, мы не можем гарантировать их бесперебойную работу.
+Для получения дополнительной информации, пожалуйста, посетите сайт http://miktex.org/kb/miktex-next.</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateDialog</name>
+    <message>
+        <location filename="../UpdateDialog.ui" line="55"></location>
+        <source>Downloading:</source>
+        <translation>Загрузка:</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.ui" line="85"></location>
+        <source>Total</source>
+        <translation>Всего</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.ui" line="107"></location>
+        <source>Packages</source>
+        <translation>Пакеты</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.ui" line="146"></location>
+        <source>Files</source>
+        <translation>Файлы</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.ui" line="185"></location>
+        <source>MB</source>
+        <translation>МБ</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.ui" line="224"></location>
+        <source>Mbit/s</source>
+        <translation>Мбит/с</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.ui" line="289"></location>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateDialogImpl</name>
+    <message>
+        <location filename="../UpdateDialog.cpp" line="231"></location>
+        <source>Close</source>
+        <translation>Закрыть</translation>
+    </message>
+    <message>
+        <location filename="../UpdateDialog.cpp" line="284"></location>
+        <source>The update operation will now be cancelled.</source>
+        <translation>Операция обновления будет отменена.</translation>
+    </message>
+</context>
+</TS>

--- a/Programs/MiKTeX/Console/Qt/translations/console_ru.ts
+++ b/Programs/MiKTeX/Console/Qt/translations/console_ru.ts
@@ -1,0 +1,1583 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>BackgroundWorker</name>
+    <message>
+        <location filename="../mainwindow.cpp" line="1032"></location>
+        <source>The MiKTeX configuration utility (initexmf) could not be found.</source>
+        <translation>Не удалось найти программу настройки MiKTeX (initexmf).</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1055"></location>
+        <source>The MiKTeX configuration utility failed for some reason. The output has been saved to a file.</source>
+        <translation>В программе настройки MiKTeX произошёл сбой по неизвестной причине . Вывод был сохранён в файл.</translation>
+    </message>
+</context>
+<context>
+    <name>FormatDefinitionDialog</name>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="14"></location>
+        <source>Format Properties</source>
+        <translation>Свойства формата</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="25"></location>
+        <source>Key:</source>
+        <translation>Ключ:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="35"></location>
+        <source>Name:</source>
+        <translation>Имя:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="45"></location>
+        <source>Compiler:</source>
+        <translation>Компилятор:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="55"></location>
+        <source>Input file:</source>
+        <translation>Входной файл:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="65"></location>
+        <source>Output file:</source>
+        <translation>Выходной файл:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="75"></location>
+        <source>Base format:</source>
+        <translation>Базовый формат:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="85"></location>
+        <source>Description:</source>
+        <translation>Описание:</translation>
+    </message>
+    <message>
+        <location filename="../formatdefinitiondialog.ui" line="102"></location>
+        <source>Exclude this format when updating all format files</source>
+        <translation>Исключить формат при обновлении всех файлов этого формата</translation>
+    </message>
+</context>
+<context>
+    <name>FormatTableModel</name>
+    <message>
+        <location filename="../FormatTableModel.cpp" line="87"></location>
+        <source>Key</source>
+        <translation>Ключ</translation>
+    </message>
+    <message>
+        <location filename="../FormatTableModel.cpp" line="89"></location>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../FormatTableModel.cpp" line="91"></location>
+        <source>Attributes</source>
+        <translation>Свойства</translation>
+    </message>
+</context>
+<context>
+    <name>LanguageTableModel</name>
+    <message>
+        <location filename="../LanguageTableModel.cpp" line="56"></location>
+        <source>Language</source>
+        <translation>Язык</translation>
+    </message>
+    <message>
+        <location filename="../LanguageTableModel.cpp" line="58"></location>
+        <source>Synonyms</source>
+        <translation>Синонимы</translation>
+    </message>
+    <message>
+        <location filename="../LanguageTableModel.cpp" line="60"></location>
+        <source>Loader</source>
+        <translation>Загрузчик</translation>
+    </message>
+    <message>
+        <location filename="../LanguageTableModel.cpp" line="62"></location>
+        <source>Package</source>
+        <translation>Пакет</translation>
+    </message>
+    <message>
+        <location filename="../LanguageTableModel.cpp" line="64"></location>
+        <source>Installed</source>
+        <translation>Установлено</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="88"></location>
+        <source>MiKTeX configuration overview</source>
+        <translation>Обзор конфигурации MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="91"></location>
+        <source>Overview</source>
+        <translation>Обзор</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="116"></location>
+        <source>Check and modify MiKTeX configuration settings</source>
+        <translation>Проверить и изменить параметры конфигурации MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="119"></location>
+        <source>Settings</source>
+        <translation>Параметры</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="144"></location>
+        <source>Check for MiKTeX updates</source>
+        <translation>Проверять наличие обновлений MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="147"></location>
+        <location filename="../mainwindow.ui" line="701"></location>
+        <source>Updates</source>
+        <translation>Обновления</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="172"></location>
+        <source>MiKTeX package management</source>
+        <translation>Управление пакетами MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="175"></location>
+        <source>Packages</source>
+        <translation>Пакеты</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="200"></location>
+        <location filename="../mainwindow.ui" line="203"></location>
+        <source>Diagnose</source>
+        <translation>Диагностика</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="228"></location>
+        <location filename="../mainwindow.ui" line="231"></location>
+        <source>Cleanup</source>
+        <translation>Очистка</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="266"></location>
+        <source>Start the TeXworks front-end</source>
+        <translation>Запустить интерфейс TeXworks</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="269"></location>
+        <location filename="../mainwindow.ui" line="2019"></location>
+        <source>TeXworks</source>
+        <translation>TeXworks</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="292"></location>
+        <source>Open a Terminal window</source>
+        <translation>Открыть окно терминала</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="295"></location>
+        <location filename="../mainwindow.ui" line="2028"></location>
+        <source>Terminal</source>
+        <translation>Терминал</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="362"></location>
+        <location filename="../mainwindow.ui" line="481"></location>
+        <source>&lt;h2&gt;Welcome!&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Добро пожаловать!&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="376"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Thank you for giving MiKTeX a try!&lt;/p&gt;&lt;p&gt;We will now finish the setup by populating the &lt;span style=" font-style:italic;"&gt;link target directory&lt;/span&gt; with symbolic links to the MiKTeX executables. The location of this directory depends on your choice:&lt;/p&gt;&lt;ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;"&gt;&lt;li style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;span style=" font-family:'Courier New';"&gt;~/bin&lt;/span&gt; for an own TeX installation.&lt;/li&gt;&lt;li style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;span style=" font-family:'Courier New';"&gt;/usr/local/bin&lt;/span&gt; for a shared (system-wide) TeX installation. This option requires administrator privileges.&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;It is possible to change the location of the link target directory later.&lt;/p&gt;&lt;p&gt;More information: &lt;a href="https://miktex.org/kb/private-vs-shared"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;KB: private vs. shared installation&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Спасибо, что решили попробовать MiKTeX!&lt;/p&gt;&lt;p&gt;Теперь мы завершим настройку, наполнив &lt;span style=" font-style:italic;"&gt;целевой каталог ссылок&lt;/span&gt; символическими ссылками на исполняемые файлы MiKTeX. Расположение этого каталога зависит от вашего выбора:&lt;/p&gt;&lt;ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;"&gt;&lt;li style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;span style=" font-family:'Courier New';"&gt;~/bin&lt;/span&gt; для отдельной пользовательской установки TeX.&lt;/li&gt;&lt;li style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;span style=" font-family:'Courier New';"&gt;/usr/local/bin&lt;/span&gt; для общей (общесистемной) установки TeX. Для этого варианта требуются права администратора.&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Расположение целевого каталога ссылок можно изменить позже.&lt;/p&gt;&lt;p&gt;Дополнительная информация: &lt;a href="https://miktex.org/kb/private-vs-shared"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;База знаний: частная и общая установка&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="410"></location>
+        <source>Finish private setup</source>
+        <translation>Завершить частную установку</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="413"></location>
+        <source>The TeX installation will be available for your own use only.</source>
+        <translation>Установка TeX будет доступна только для одного пользователя.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="420"></location>
+        <source>Restart as administrator and finish setup</source>
+        <translation>Перезагрузитесь от имени администратора и завершите настройку</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="423"></location>
+        <source>The TeX installation will be available for all users.</source>
+        <translation>Установка TeX будет доступна всем пользователям.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="436"></location>
+        <source>Please wait a few moments. It doesn't take too long...</source>
+        <translation>Пожалуйста, подождите. Это не должно занять много времени...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="495"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is MiKTeX Console. The program will assist you in managing your MiKTeX configuration.&lt;/p&gt;&lt;p&gt;If you want, you can start with an online tutorial: &lt;a href="https://miktex.org/howto/miktex-console"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;HOWTO: manage MiKTeX with the MiKTeX Console&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translatorcomment>Do not translate the HOWTO title</translatorcomment>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это консоль MiKTeX. Программа поможет вам управлять вашей конфигурацией MiKTeX.&lt;/p&gt;&lt;p&gt;Если вы хотите, вы можете начать с онлайн-руководства: &lt;a href="https://miktex.org/howto/miktex-console"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;ИНСТРУКЦИЯ: управляйте MiKTeX с помощью консоли MiKTeX&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="524"></location>
+        <source>PATH issue</source>
+        <translation>Проблема с расположением</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="533"></location>
+        <location filename="../mainwindow.ui" line="1227"></location>
+        <source>Links to the MiKTeX executables have been installed in:</source>
+        <translation>Ссылки на исполняемые файлы MiKTeX были установлены  по пути:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="547"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This directory is not in the search path for executables or it is at the wrong position in the path. You can fix this issue by adding the directory to the environment variable PATH. This makes it possible to invoke the MiKTeX executables everywhere.&lt;/p&gt;&lt;p&gt;More information: &lt;a href="https://miktex.org/howto/modify-path"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;HOWTO: modify PATH&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translatorcomment>Do not translate the HOWTO title</translatorcomment>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Этот каталог отсутствует в пути поиска исполняемых программ. Устраните проблему, добавив каталог в переменную среды PATH. Программы MiKTeX могут быть доступны в любом месте.&lt;/p&gt;&lt;p&gt;дополнительная информация: &lt;a href="https://miktex.org/howto/modify-path"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;Инструкция: изменение переменной PATH&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="562"></location>
+        <source>Fix now</source>
+        <translation>Исправить сейчас</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="603"></location>
+        <location filename="../mainwindow.ui" line="622"></location>
+        <location filename="../mainwindow.ui" line="666"></location>
+        <source>Operation mode</source>
+        <translation>Режим работы</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="609"></location>
+        <source>You have installed MiKTeX for your own use.</source>
+        <translation>Вы установили MiKTeX для текущего пользователя.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="628"></location>
+        <source>Please decide how you wish to continue:</source>
+        <translation>Пожалуйста, решите, как вы хотите продолжить:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="641"></location>
+        <location filename="../mainwindow.ui" line="1968"></location>
+        <source>Switch to MiKTeX administrator mode</source>
+        <translation>Перейти в режим администратора MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="644"></location>
+        <source>Restart MiKTeX Console with elevated privileges and switch to MiKTeX administrator mode.
+Use this option, if you want to operate on the shared (system-wide) MiKTeX configuration.</source>
+        <translation>Перезапустить MiKTeX Console с расширенными правами и перейти в режим администратора MiKTeX.
+Используйте этот параметр, если вы хотите работать с общей (общесистемной) конфигурацией MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="652"></location>
+        <source>Stay in MiKTeX user mode</source>
+        <translation>Остаться в пользовательском режиме MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="655"></location>
+        <source>Continue to work with MiKTeX Console in MiKTeX user mode.
+Use this option, if you want to operate on your own MiKTeX configuration.</source>
+        <translation>Продолжать работать с MiKTeX Console в пользовательском режиме MiKTeX.
+Используйте этот параметр, если вы хотите отредактировать вашу конфигурацию MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="672"></location>
+        <source>You are a MiKTeX administrator: this tool currently operates on the shared (system-wide) MiKTeX configuration.</source>
+        <translation>Вы являетесь администратором MiKTeX: в настоящее время этот инструмент редактирует общую (общесистемную) конфигурацию MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="734"></location>
+        <location filename="../mainwindow.cpp" line="346"></location>
+        <source>You can now check for package updates.</source>
+        <translation>Теперь вы можете проверять наличие обновлений.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="746"></location>
+        <location filename="../mainwindow.ui" line="1462"></location>
+        <location filename="../mainwindow.ui" line="2115"></location>
+        <source>Check for updates</source>
+        <translation>Проверять наличие обновлений</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="778"></location>
+        <source>There are currently no updates available. Try again tomorrow.</source>
+        <translation>В настоящее время обновлений нет. Попробуйте завтра снова.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="788"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;There are updates available! You can review the updates on the &lt;a href="#updates"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;Updates page&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Доступны обновления! Вы можете следить за обновлениями на &lt;a href="#updates"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;Странице обновлений&lt;/span&gt;&lt;/a&gt; .&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="817"></location>
+        <source>Upgrade</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="829"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can upgrade your minimal TeX installation to a standard TeX installation. This is completely optional because MiKTeX is a scalable TeX distribution which installs missing packages on-the-fly. More information:&lt;/p&gt;&lt;ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;"&gt;&lt;li style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;a href="https://miktex.org/howto/upgrade"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;HOWTO: upgrade MiKTeX&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;&lt;li style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;a href="https://miktex.org/kb/just-enough-tex"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;KB: “Just enough TeX”&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Вы можете обновить свою минимальную установку TeX до стандартной установки TeX. Это совершенно необязательно, так как необходимые пакеты будут автоматически переустанавливаться по мере необходимости. дополнительная информация:&lt;/p&gt;&lt;ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;"&gt;&lt;li style=" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;a href="https://miktex.org/howto/upgrade"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;КАК обновить MiKTeX&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;&lt;li style=" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;a href="https://miktex.org/kb/just-enough-tex"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;КБ: “Достаточно текса”.&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="844"></location>
+        <source>Upgrade now</source>
+        <translation>Обновить сейчас</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="925"></location>
+        <source>&lt;h2&gt;Settings&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Настройки&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="943"></location>
+        <source>General</source>
+        <translation>Общее</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="949"></location>
+        <source>User interface</source>
+        <translation>Пользовательский интерфейс</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="957"></location>
+        <source>Language:</source>
+        <translation>Язык:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="985"></location>
+        <source>Package installation</source>
+        <translation>Установка пакета</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1013"></location>
+        <location filename="../mainwindow.ui" line="1243"></location>
+        <location filename="../mainwindow.ui" line="1422"></location>
+        <location filename="../mainwindow.ui" line="1627"></location>
+        <source>Change...</source>
+        <translation>Изменить...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1024"></location>
+        <source>You can choose whether missing packages are to be installed automatically (on-the-fly):</source>
+        <translation>Вы можете выбрать, хотите ли вы, чтобы отсутствующие пакеты устанавливались автоматически (на лету:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1054"></location>
+        <source>Always</source>
+        <translation>Всегда</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1079"></location>
+        <source>For anyone who uses this computer (all users)</source>
+        <translation>Для всех, кто пользуется этим компьютером (все пользователи)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1088"></location>
+        <source>Ask me</source>
+        <translation>Спрашивать меня</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1095"></location>
+        <source>Never</source>
+        <translation>Никогда</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1111"></location>
+        <source>Paper format</source>
+        <translation>Формат бумаги</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1874"></location>
+        <source>This leaves you with a fresh TeX installation. Use this option if you intend to remove MiKTeX.</source>
+        <translation>Это оставляет после себя свежую установку TeX. Используйте эту опцию, если вы планируете удалить MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2145"></location>
+        <source>Remove package</source>
+        <translation>Удалить пакет</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2151"></location>
+        <source>Removes the selected packages.</source>
+        <translation>Удаляет выбранные пакеты.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1161"></location>
+        <source>Directories</source>
+        <translation>Каталоги</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1167"></location>
+        <source>TEXMF root directories</source>
+        <translation>Корневые каталоги TEXMF</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1209"></location>
+        <source>Link target directory</source>
+        <translation>Целевой каталог для ссылок</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1255"></location>
+        <source>Log directory</source>
+        <translation>Каталог журналов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1273"></location>
+        <source>Log files will be written to:</source>
+        <translation>Файлы журналов записываются в:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1304"></location>
+        <source>Formats</source>
+        <translation>Форматы</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1328"></location>
+        <source>Languages</source>
+        <translation>Языки</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1384"></location>
+        <source>&lt;h2&gt;Updates&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Обновления&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1469"></location>
+        <source>Update now</source>
+        <translation>Обновить сейчас</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1575"></location>
+        <source>&lt;h2&gt;Packages&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Пакеты&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1677"></location>
+        <source>&lt;h2&gt;Diagnose&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Диагностика&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1691"></location>
+        <source>Report</source>
+        <translation>Отчёт</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1697"></location>
+        <source>The report contains information about your MiKTeX setup.</source>
+        <translation>Отчёт содержит информацию о вашем экземпляре MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1706"></location>
+        <location filename="../mainwindow.ui" line="1760"></location>
+        <source>Open...</source>
+        <translation>Открыть...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1728"></location>
+        <source>When you issue a ticket, you should include the report as an attachment.</source>
+        <translation>Когда вы сообщаете о проблеме, вы должны приложить отчёт.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1738"></location>
+        <source>Log files</source>
+        <translation>Файлы журналов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1403"></location>
+        <location filename="../mainwindow.ui" line="1594"></location>
+        <source>Retrieve from:</source>
+        <translation>Извлекать из:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="993"></location>
+        <source>Packages are retrieved from:</source>
+        <translation>Пакеты будут получены из:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1119"></location>
+        <source>Select your preferred paper format:</source>
+        <translation>Выберите предпочитаемый формат бумаги:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1431"></location>
+        <location filename="../mainwindow.ui" line="1601"></location>
+        <source>Install in:</source>
+        <translation>Устанавливать в:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1744"></location>
+        <source>If something goes wrong, you can check the log files:</source>
+        <translation>Если что-то пойдёт не так, вы можете проверить файлы журнала:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1173"></location>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the list of TEXMF root directories. The order in the list determines the search order of files. A root directory can serve one or more purposes (&lt;span style=" font-style:italic;"&gt;Config&lt;/span&gt;, &lt;span style=" font-style:italic;"&gt;Data&lt;/span&gt;, &lt;span style=" font-style:italic;"&gt;Install)&lt;/span&gt;. A &lt;span style=" font-style:italic;"&gt;common&lt;/span&gt; root directory is shared by all users. More information:&lt;br/&gt;&lt;a href="https://miktex.org/kb/texmf-roots"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;KB: TEXMF root directories&lt;/span&gt;&lt;/a&gt;&lt;br/&gt;&lt;a href="https://miktex.org/faq/local-additions"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;FAQ: Which is the best directory to keep my .sty files?&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это список корневых каталогов TEXMF. Порядок в списке определяет очерёдность поиска файлов. Корневой каталог может служить для одной или нескольких целей (&lt;span style=" font-style:italic;"&gt;Config&lt;/span&gt; — конфигурация, &lt;span style=" font-style:italic;"&gt;Data&lt;/span&gt; — данные, &lt;span style=" font-style:italic;"&gt;Install&lt;/span&gt; — установка). &lt;span style=" font-style:italic;"&gt;Общий&lt;/span&gt; корневой каталог используется всеми пользователями совместно. Дополнительная информация:&lt;br/&gt;&lt;a href="https://miktex.org/kb/texmf-roots"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;База знаний: корневые каталоги TEXMF&lt;/span&gt;&lt;/a&gt;&lt;br/&gt;&lt;a href="https://miktex.org/faq/local-additions"&gt;&lt;span style=" text-decoration: underline; color:#007af4;"&gt;ЧаВо: какой каталог лучше всего подходит для хранения моих .sty файлов?&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1782"></location>
+        <source>When you issue a ticket, you should include relevant log files as attachments.</source>
+        <translation>Когда вы оформляете заявку, вы должны включить соответствующие файлы журнала в качестве вложений.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1792"></location>
+        <source>Online help</source>
+        <translation>Онлайн-справка</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1798"></location>
+        <source>Please visit the &lt;a href="https://miktex.org"&gt;MiKTeX project page&lt;/a&gt;, if you need assistance.</source>
+        <translation>Пожалуйста, посетите &lt;a href="https://miktex.org "&gt;Страницу проекта MiKTeX&lt;/a&gt;, если вам нужна помощь по использованию MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1840"></location>
+        <source>&lt;h2&gt;Cleanup&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Очистка&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1854"></location>
+        <source>To clean up your TeX installation, use one of the following options.</source>
+        <translation>Выберите один из следующих вариантов, чтобы очистить установку TeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1861"></location>
+        <location filename="../mainwindow.ui" line="2288"></location>
+        <source>Reset personal MiKTeX configuration</source>
+        <translation>Сброс личной конфигурации MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1864"></location>
+        <source>This resets (removes) your personal MiKTeX configuration.</source>
+        <translation>Это приведёт к сбросу вашей личной конфигурации MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1871"></location>
+        <source>Reset the TeX installation to factory defaults</source>
+        <translation>Восстановить заводские настройки установки TeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1881"></location>
+        <location filename="../mainwindow.ui" line="2283"></location>
+        <source>Remove MiKTeX</source>
+        <translation>Удалить MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1884"></location>
+        <source>This removes MiKTeX from your computer.
+To avoid leftovers, all MiKTeX users should first reset their personal MiKTeX configuration.</source>
+        <translation>Это приведёт к удалению MiKTeX с вашего компьютера.\n
+Чтобы избежать каких-либо остатков, все пользователи MiKTeX должны предварительно сбросить свою личную конфигурацию MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1935"></location>
+        <source>&amp;File</source>
+        <translation>&amp;Файл</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1943"></location>
+        <source>&amp;Help</source>
+        <translation>&amp;Справка</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1949"></location>
+        <source>Tasks</source>
+        <translation>Задачи</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1965"></location>
+        <source>Switch to MiKTeX &amp;administrator mode</source>
+        <translation>Перейти в режим а&amp;дминистратора MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1971"></location>
+        <source>Restarts this application with elevated privileges and switches to MiKTeX administrator mode.</source>
+        <translation>Перезагружает приложение с расширенными правами и переключается в режим администратора MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1976"></location>
+        <source>E&amp;xit</source>
+        <translation>&amp;Закрыть</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1979"></location>
+        <source>Exit</source>
+        <translation>Закрыть</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1982"></location>
+        <source>Quits the application.</source>
+        <translation>Завершает работу приложения.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1991"></location>
+        <source>About &amp;MiKTeX Console...</source>
+        <translation>О &amp;MiKTeX Console...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1994"></location>
+        <source>About</source>
+        <translation>О программе</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1997"></location>
+        <source>Shows the version number and copying conditions.</source>
+        <translation>Показывает номер версии и условия распространения.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2002"></location>
+        <source>&amp;Hide</source>
+        <translation>&amp;Скрыть</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2005"></location>
+        <source>Hide</source>
+        <translation>Скрыть</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2010"></location>
+        <source>&amp;Restore</source>
+        <translation>Восстановить</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2037"></location>
+        <source>Remove root directory</source>
+        <translation>Удалить корневой каталог</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2040"></location>
+        <location filename="../mainwindow.ui" line="2148"></location>
+        <location filename="../mainwindow.ui" line="2249"></location>
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2043"></location>
+        <source>Removes the selected TEXMF root directory from the list</source>
+        <translation>Удаляет из списка выбранный корневой каталог TEXMF</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2052"></location>
+        <source>Add root directory</source>
+        <translation>Добавить корневой каталог</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2055"></location>
+        <location filename="../mainwindow.ui" line="2234"></location>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2058"></location>
+        <source>Adds a TEXMF root directory to the list</source>
+        <translation>Добавляет корневой каталог TEXMF в список</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2067"></location>
+        <source>Move down</source>
+        <translation>Переместить вниз</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2070"></location>
+        <source>Down</source>
+        <translation>Вниз</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2073"></location>
+        <source>Moves the selected TEXMF root directory down in the list</source>
+        <translation>Перемещает выбранный корневой каталог TEXMF вниз по списку</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2082"></location>
+        <source>Move up</source>
+        <translation>Переместить Вверх</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2085"></location>
+        <source>Up</source>
+        <translation>Вверх</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2088"></location>
+        <source>Moves the selected TEXMF root directory up in the list</source>
+        <translation>Перемещает выбранный корневой каталог TEXMF вверх по списку</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2093"></location>
+        <source>Refresh file name database</source>
+        <translation>Обновить базу данных имён файлов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2096"></location>
+        <source>Refresh FNDB</source>
+        <translation>Обновить базу данных имён файлов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2099"></location>
+        <source>Refreshes the file name database</source>
+        <translation>Обновляет базу данных имён файлов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2104"></location>
+        <source>Refresh font map files</source>
+        <translation>Обновить файлы карт шрифтов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2107"></location>
+        <source>Refresh font maps</source>
+        <translation>Обновить карты шрифтов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2110"></location>
+        <source>Refreshes the font map files</source>
+        <translation>Обновляет файлы карт шрифтов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2118"></location>
+        <source>Check updates</source>
+        <translation>Проверить обновления</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2121"></location>
+        <source>Checks for MiKTeX package updates</source>
+        <translation>Проверяет наличие обновлений пакета MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2130"></location>
+        <source>Install package</source>
+        <translation>Установить пакет</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2133"></location>
+        <source>Install</source>
+        <translation>Установить</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2136"></location>
+        <source>Installs the selected packages.</source>
+        <translation>Устанавливает выбранные пакеты.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2160"></location>
+        <source>Package information</source>
+        <translation>Информация о пакете</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2163"></location>
+        <source>Info</source>
+        <translation>Информация</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2166"></location>
+        <source>Shows package information.</source>
+        <translation>Показывает информацию о пакете.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2175"></location>
+        <source>Filter packages</source>
+        <translation>Фильтр пакетов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2178"></location>
+        <source>Apply the package filter</source>
+        <translation>Применить фильтр пакетов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2181"></location>
+        <source>Applies the filter on the package list view.</source>
+        <translation>Применяет фильтр к представлению списка пакетов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2190"></location>
+        <source>Update package database</source>
+        <translation>Обновить базу данных пакетов</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2193"></location>
+        <source>Update DB</source>
+        <translation>Обновление базы данных</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2196"></location>
+        <source>Updates the package database.</source>
+        <translation>Обновляет базу данных пакетов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2205"></location>
+        <source>Open</source>
+        <translation>Открыть</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2208"></location>
+        <source>Open in file browser</source>
+        <translation>Открыть в проводнике</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2211"></location>
+        <source>Opens the TEXMF root directory in the system file browser.</source>
+        <translation>Открывает корневой каталог TEXMF в проводнике системы.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2216"></location>
+        <source>Factory reset</source>
+        <translation>Сбросить к заводским настройкам</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2219"></location>
+        <source>Factory Reset</source>
+        <translation>Сбросить к заводским настройкам</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2222"></location>
+        <source>Resets the TeX installation to the factory defaults.</source>
+        <translation>Возвращает установку TeX к заводским настройкам.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2231"></location>
+        <source>Add format</source>
+        <translation>Добавить формат</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2237"></location>
+        <source>Adds a new format to the list</source>
+        <translation>Добавляет новый формат в список</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2246"></location>
+        <source>Remove format</source>
+        <translation>Удалить формат</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2252"></location>
+        <source>Removes the selected  format from the list</source>
+        <translation>Удаляет выбранный формат из списка</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2261"></location>
+        <source>Format properties</source>
+        <translation>Свойства формата</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2264"></location>
+        <source>Properties</source>
+        <translation>Свойства</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2267"></location>
+        <source>Shows format properties.</source>
+        <translation>Показывает свойства формата.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2272"></location>
+        <source>Build format</source>
+        <translation>Создать формат</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2275"></location>
+        <source>Build</source>
+        <translation>Создание</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2278"></location>
+        <source>Builds the selected format.</source>
+        <translation>Создаёт выбранный формат.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2291"></location>
+        <source>Removes MiKTeX data and configuration settings of the current user</source>
+        <translation>Удаляет данные MiKTeX и настройки конфигурации текущего пользователя</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="195"></location>
+        <source>A MiKTeX setup issue has been detected.</source>
+        <translation>Обнаружена проблема с настройкой MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="200"></location>
+        <location filename="../mainwindow.cpp" line="270"></location>
+        <source>Remedy:</source>
+        <translation>Устранение:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="205"></location>
+        <location filename="../mainwindow.cpp" line="276"></location>
+        <source>For more information, visit &lt;a href='%1'&gt;%2&lt;/a&gt;</source>
+        <translation>Для получения дополнительной информации посетите страницу &lt;a href='%1'&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="229"></location>
+        <source>A task is running in the background. Are you sure you want to quit %1?</source>
+        <translation>Задача выполняется в фоновом режиме. Вы уверены, что хотите выйти из %1?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="238"></location>
+        <location filename="../mainwindow.cpp" line="646"></location>
+        <source>There are pending updates. Are you sure you want to quit %1?</source>
+        <translation>Есть ожидающие обновления. Вы уверены, что хотите выйти из %1?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="284"></location>
+        <source>Do you want to see the error details?</source>
+        <translation>Хотите просмотреть подробную информацию об ошибке?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="324"></location>
+        <source>Finish shared setup</source>
+        <translation>Завершить общую настройку</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="494"></location>
+        <source>MiKTeX Problem</source>
+        <translation>Проблема с MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="498"></location>
+        <source>MiKTeX Update</source>
+        <translation>Обновление MiKTeX</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="628"></location>
+        <source>&lt;p&gt;%1 is free software. You are welcome to redistribute it under certain conditions.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;%1 является свободным программным обеспечением. Вы можете распространять %1 при соблюдении определённых условиях.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="629"></location>
+        <source>&lt;p&gt;%1 comes WITH ABSOLUTELY NO WARRANTY OF ANY KIND.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;%1 поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="631"></location>
+        <source>&lt;p&gt;English translation kindly contributed by Jane Doe.&lt;/p&gt;</source>
+        <extracomment>Please translate this text if you want to be included in the about dialog.</extracomment>
+        <translation>&lt;p&gt;Перевод на русский язык любезно предоставлен Данилом Костенковым.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="636"></location>
+        <source>&lt;p&gt;You can support the project:&lt;br&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;&lt;br&gt;Thank you!&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Вы можете поддержать проект:&lt;br&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;&lt;br&gt;Спасибо!&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="718"></location>
+        <source>No graphical sudo frontend is available. Please install 'pkexec', 'kdesu' (KDE) or 'gksu' (Gnome). Alternatively, you can enter 'sudo miktex-console %1' in a terminal window.</source>
+        <translation>Графический интерфейс sudo недоступен. Пожалуйста, установите "pkexec", "kdesu" (KDE) или "gksu" (Gnome). В качестве альтернативы вы можете ввести "sudo miktex-console %1" в окне терминала.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="806"></location>
+        <source>Finishing the MiKTeX setup...</source>
+        <translation>Завершение настройки MiKTeX...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="832"></location>
+        <source>Something went wrong while finishing the MiKTeX setup.</source>
+        <translation>Что-то пошло не так при завершении настройки MiKTeX.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="862"></location>
+        <source>The PATH environment variable has been successfully modified.</source>
+        <translation>Переменная PATH успешно изменена.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="868"></location>
+        <source>The PATH environment variable could not be modified.</source>
+        <translation>Не удалось изменить переменную PATH.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"></location>
+        <source>Installing packages...</source>
+        <translation>Установка пакетов...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="923"></location>
+        <location filename="../mainwindow.cpp" line="1344"></location>
+        <source>Done</source>
+        <translation>Готово</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="927"></location>
+        <source>Something went wrong while installing packages.</source>
+        <translation>Что-то пошло не так при установке пакетов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="928"></location>
+        <location filename="../mainwindow.cpp" line="1260"></location>
+        <location filename="../mainwindow.cpp" line="1358"></location>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="943"></location>
+        <location filename="../mainwindow.cpp" line="1379"></location>
+        <source>we're almost done</source>
+        <translation>мы почти закончили</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="947"></location>
+        <location filename="../mainwindow.cpp" line="1383"></location>
+        <source>(updating package database)</source>
+        <translation>(Обновляется база данных пакетов)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="951"></location>
+        <location filename="../mainwindow.cpp" line="1387"></location>
+        <source>(downloading: %1)</source>
+        <translation>(загрузка: %1)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="955"></location>
+        <location filename="../mainwindow.cpp" line="1391"></location>
+        <source>(installing: %1)</source>
+        <translation>(установка: %1)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="964"></location>
+        <source>Upgrade in progress...</source>
+        <translation>Выполняется обновление...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="966"></location>
+        <location filename="../mainwindow.cpp" line="1402"></location>
+        <source>(initializing)</source>
+        <translation>(Запуск)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="997"></location>
+        <source>Refreshing file name database...</source>
+        <translation>Обновляется база данных имён файлов...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1004"></location>
+        <source>Something went wrong while refreshing the file name database.</source>
+        <translation>Что-то пошло не так при обновлении базы данных имён файлов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1084"></location>
+        <source>Refreshing font map files...</source>
+        <translation>Обновление файлов карты шрифтов...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1091"></location>
+        <source>Something went wrong while refreshing the font map files.</source>
+        <translation>Что-то пошло не так при обновлении файлов карты шрифтов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1117"></location>
+        <source>Last checked: %1</source>
+        <translation>Последняя проверка: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1121"></location>
+        <source>You have not yet checked for updates.</source>
+        <translation>Вы ещё не проверяли наличие обновлений.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1129"></location>
+        <location filename="../mainwindow.cpp" line="1240"></location>
+        <source>There are currently no updates available.</source>
+        <translation>В настоящее время обновления недоступны.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1135"></location>
+        <source>The following updates are available:</source>
+        <translation>Доступны следующие обновления:</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1137"></location>
+        <source>Updates (%1)</source>
+        <translation>Обновления (%1)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1222"></location>
+        <location filename="../mainwindow.cpp" line="1272"></location>
+        <location filename="../mainwindow.cpp" line="1273"></location>
+        <source>Checking for updates...</source>
+        <translation>Проверка наличия обновлений...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1246"></location>
+        <source>There is an update available!</source>
+        <translation>Доступно обновление!</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1259"></location>
+        <source>Something went wrong while checking for updates.</source>
+        <translation>Что-то пошло не так при проверке обновлений.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2555"></location>
+        <source>&lt;p&gt;You are about to remove the following:&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Вы собираетесь удалить следующее:&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2558"></location>
+        <source>&lt;li&gt;MiKTeX registry keys under &lt;tt&gt;HKEY_CURRENT_USER&lt;/tt&gt;&lt;/li&gt;</source>
+        <translation>&lt;li&gt;Ключ реестра MiKTeX &lt;tt&gt;HKEY_CURRENT_USER&lt;/tt&gt;&lt;/li&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2726"></location>
+        <source>&lt;h3&gt;Remove MiKTeX&lt;/h3&gt;</source>
+        <translation>&lt;h3&gt;Удалить MiKTeX&lt;/h3&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2738"></location>
+        <source>Removing MiKTeX...</source>
+        <translation>Удаление MiKTeX...</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../mainwindow.cpp" line="1250"></location>
+        <source>There are %n updates available!</source>
+        <translation><numerusform>Доступно %n обновление!</numerusform><numerusform>Доступны %n обновления!</numerusform><numerusform>Доступны %n обновлений!</numerusform></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1335"></location>
+        <source>Installing package updates...</source>
+        <translation>Установка обновлений пакетов...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1357"></location>
+        <source>Something went wrong while installing package updates.</source>
+        <translation>Что-то пошло не так при установке обновлений пакетов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1400"></location>
+        <source>Update in progress...</source>
+        <translation>Выполняется обновление...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1438"></location>
+        <source>The language change will take effect after restart.</source>
+        <translation>Изменение языка вступит в силу после перезагрузки.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1439"></location>
+        <source>Restart now</source>
+        <translation>Перезагрузить сейчас</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1440"></location>
+        <source>Later</source>
+        <translation>Позже</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1734"></location>
+        <source>This does not look like a &lt;a href="https://miktex.org/kb/tds"&gt;TDS-compliant&lt;/a&gt; root directory. Are you sure you want to add it?</source>
+        <translation>Это не похоже на &lt;a href="https://miktex.org/kb/tds"&gt;Корневой каталог, совместимый с TDS. Вы уверены, что хотите его добавить?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1879"></location>
+        <source>Change Link Target Directory</source>
+        <translation>Изменить целевой каталог ссылок</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1887"></location>
+        <source>Changing link target directory...</source>
+        <translation>Изменение целевого каталога ссылок...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1894"></location>
+        <source>Something went wrong while changing the link target directory.</source>
+        <translation>Что-то пошло не так при изменении целевого каталога ссылок.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2001"></location>
+        <source>Are you sure you want to remove the selected format definition?</source>
+        <translation>Вы уверены, что хотите удалить выбранное значение формата?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2083"></location>
+        <source>Building format %1...</source>
+        <translation>Создание формата %1...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2083"></location>
+        <source>Building formats...</source>
+        <translation>Создание форматов...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2090"></location>
+        <source>Something went wrong while building formats.</source>
+        <translation>Что-то пошло не так при создании форматов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2313"></location>
+        <source>Your MiKTeX installation will now be updated:
+
+</source>
+        <translation>Ваша установка MiKTeX будет обновлена:
+
+</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../mainwindow.cpp" line="2314"></location>
+        <source>%n package(s) will be installed
+</source>
+        <translation><numerusform>Будет установлен %n пакет
+</numerusform><numerusform>Будут установлены %n пакета
+</numerusform><numerusform>Будут установлены %n пакетов
+</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../mainwindow.cpp" line="2315"></location>
+        <source>%n package(s) will be removed</source>
+        <translation><numerusform>Будет удалён %n пакет</numerusform><numerusform>Будет удалено %n пакета</numerusform><numerusform>Будут удалены %n пакетов</numerusform></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2371"></location>
+        <source>Updating the package database...</source>
+        <translation>Обновление базы данных пакетов...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2378"></location>
+        <source>Something went wrong while updating the package database.</source>
+        <translation>Что-то пошло не так при обновлении базы данных пакетов.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2554"></location>
+        <source>&lt;h3&gt;Reset personal MiKTeX configuration&lt;/h3&gt;</source>
+        <translation>&lt;h3&gt;Сброс личной конфигурации MiKTeX&lt;/h3&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2569"></location>
+        <source>&lt;li&gt;Directory &lt;tt&gt;%1&lt;/tt&gt;&lt;/li&gt;</source>
+        <translation>&lt;li&gt;Каталог &lt;tt&gt;%1&lt;/tt&gt;&lt;/li&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2573"></location>
+        <source>&lt;p&gt;Are you sure?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Вы уверены?&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2583"></location>
+        <source>Resetting personal MiKTeX configuration...</source>
+        <translation>Личная конфигурация MiKTeX будет сброшена...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2590"></location>
+        <source>The personal MiKTeX configuration has been reset.
+
+The application window will now be closed.</source>
+        <translation>Личная конфигурация MiKTeX была сброшена.
+
+Сейчас окно приложения будет закрыто.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2594"></location>
+        <source>Something went wrong while resetting your personal MiKTeX configuration.
+
+The application window will now be closed.</source>
+        <translation>Что-то пошло не так при сбросе личной конфигурации MiKTeX.
+
+Окно приложения будет закрыто.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2648"></location>
+        <source>&lt;h3&gt;Reset the TeX installation to factory defaults&lt;/h3&gt;</source>
+        <translation>&lt;h3&gt;Сброс настроек установки TeX к заводским настройкам&lt;/h3&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2649"></location>
+        <source>&lt;p&gt;You are about to reset your TeX installation. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.</source>
+        <translation>&lt;p&gt;Вы находитесь в процессе восстановления заводских настроек установки TeX. Все корневые каталоги TEXMF будут удалены, вы потеряете все настройки конфигурации, файлы журналов, файлы данных и пакеты.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2650"></location>
+        <source> In other words: your TeX installation will be restored to its original state, as when it was first installed.&lt;/p&gt;</source>
+        <translation> Другими словами, ваша установка TeX будет возвращена в исходное состояние, в котором она была после первоначальной установки.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2651"></location>
+        <location filename="../mainwindow.cpp" line="2728"></location>
+        <source>Are you sure?</source>
+        <translation>Вы уверены?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2661"></location>
+        <source>Resetting the TeX installation...</source>
+        <translation>Сброс установки TeX до заводских настроек...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2668"></location>
+        <source>The TeX installation has been restored to its initial state.
+
+The application window will now be closed.</source>
+        <translation>Установка TeX была сброшена до заводских настроек.
+
+Сейчас окно приложения будет закрыто.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2672"></location>
+        <location filename="../mainwindow.cpp" line="2749"></location>
+        <source>
+
+The application window will now be closed.</source>
+        <translation>
+
+Сейчас окно приложения будет закрыто.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2727"></location>
+        <source>&lt;p&gt;You are about to remove MiKTeX from your computer. All TEXMF root directories will be removed and you will lose all configuration settings, log files, data files and packages.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Вы собираетесь удалить MiKTeX с вашего компьютера. Все корневые каталоги TEXMF будут удалены, вы потеряете все настройки конфигурации, файлы журналов, файлы данных и пакеты.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2745"></location>
+        <source>MiKTeX has been removed from your computer.
+
+The application window will now be closed.</source>
+        <translation>Программа MiKTeX была удалена с вашего компьютера.
+
+Окно приложения будет закрыто.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2801"></location>
+        <source>%1 needs to be closed.</source>
+        <translation>%1 должно быть закрыто.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2810"></location>
+        <source>%1 needs to be restarted.</source>
+        <translation>%1 должно быть перезагружено.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.h" line="93"></location>
+        <source>Sorry, something went wrong.</source>
+        <translation>Извините, что-то пошло не так.</translation>
+    </message>
+</context>
+<context>
+    <name>PackageTableModel</name>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="89"></location>
+        <location filename="../PackageTableModel.cpp" line="93"></location>
+        <source>Admin</source>
+        <translation>Администратор</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="89"></location>
+        <location filename="../PackageTableModel.cpp" line="93"></location>
+        <location filename="../PackageTableModel.cpp" line="97"></location>
+        <source>User</source>
+        <translation>Пользователь</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="130"></location>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="132"></location>
+        <source>Category</source>
+        <translation>Категория</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="134"></location>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="136"></location>
+        <source>Packaged on</source>
+        <translation>Упаковано в</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="138"></location>
+        <source>Installed on</source>
+        <translation>Установлено на</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="140"></location>
+        <source>Installed by</source>
+        <translation>Установлено</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="142"></location>
+        <source>Title</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="../PackageTableModel.cpp" line="144"></location>
+        <source>Files</source>
+        <translation>Файлы</translation>
+    </message>
+</context>
+<context>
+    <name>RepositoryTableModel</name>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="72"></location>
+        <source>&lt;Random package repository on the Internet&gt;</source>
+        <translation>&lt;Любой репозиторий в Интернете&gt;</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="108"></location>
+        <source>Url</source>
+        <translation>URL-адрес</translation>
+    </message>
+    <message>
+        <location filename="../RepositoryTableModel.cpp" line="110"></location>
+        <source>Release State</source>
+        <translation>Состояние выпуска</translation>
+    </message>
+</context>
+<context>
+    <name>RootTableModel</name>
+    <message>
+        <location filename="../RootTableModel.cpp" line="121"></location>
+        <source>Path</source>
+        <translation>Расположение</translation>
+    </message>
+    <message>
+        <location filename="../RootTableModel.cpp" line="123"></location>
+        <source>Purposes</source>
+        <translation>Цели</translation>
+    </message>
+    <message>
+        <location filename="../RootTableModel.cpp" line="125"></location>
+        <source>Attributes</source>
+        <translation>Свойства</translation>
+    </message>
+</context>
+<context>
+    <name>UILanguageTableModel</name>
+    <message>
+        <location filename="../UILanguageTableModel.cpp" line="72"></location>
+        <source>&lt;System Language&gt;</source>
+        <translation>&lt;Язык системы&gt;</translation>
+    </message>
+    <message>
+        <location filename="../UILanguageTableModel.cpp" line="103"></location>
+        <source>Language</source>
+        <translation>Язык</translation>
+    </message>
+    <message>
+        <location filename="../UILanguageTableModel.cpp" line="105"></location>
+        <source>Locale</source>
+        <translation>Локализация</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateTableModel</name>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="98"></location>
+        <location filename="../UpdateTableModel.cpp" line="105"></location>
+        <source>install</source>
+        <translation>установить</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="100"></location>
+        <location filename="../UpdateTableModel.cpp" line="107"></location>
+        <source>remove</source>
+        <translation>удалить</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="116"></location>
+        <source>update not possible</source>
+        <translation>обновление невозможно</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="118"></location>
+        <source>update only possible in admin mode</source>
+        <translation>обновление возможно только в режиме администратора</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="120"></location>
+        <source>removal only possible in admin mode</source>
+        <translation>удаление возможно только в режиме администратора</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="122"></location>
+        <source>optional</source>
+        <translation>необязательно</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="124"></location>
+        <source>required</source>
+        <translation>обязательно</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="128"></location>
+        <source>competing installations (system vs. user)</source>
+        <translation>конфликтующие установки (системная и пользовательская)</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="132"></location>
+        <source>removed from repository</source>
+        <translation>удалено из репозитория</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="135"></location>
+        <source>to be repaired</source>
+        <translation>необходимо исправить</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="137"></location>
+        <source>release state change</source>
+        <translation>изменение состояния выпуска</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="197"></location>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="199"></location>
+        <source>Installed</source>
+        <translation>Установлено</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="201"></location>
+        <source>Available</source>
+        <translation>Доступно</translation>
+    </message>
+    <message>
+        <location filename="../UpdateTableModel.cpp" line="203"></location>
+        <source>Action</source>
+        <translation>Действие</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../main.cpp" line="290"></location>
+        <source>%1 is already running.</source>
+        <translation>%1 уже выполняется.</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="299"></location>
+        <source>%1 cannot be started.
+
+Remedy: remove %2</source>
+        <translation>Не удаётся запустить %1.
+
+Решение: удалите %2</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="395"></location>
+        <source>Administrator mode was requested (--admin), but the program is not running as Administrator.</source>
+        <translation>Был запрошен режим администратора (--admin), но программа запущена не от имени администратора.</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="397"></location>
+        <source>Administrator mode was requested (--admin), but the program is not running as root.</source>
+        <translation>Был запрошен режим администратора (--admin), но программа запущена не от имени пользователя root.</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="484"></location>
+        <location filename="../main.cpp" line="503"></location>
+        <source>Sorry, but something went wrong.
+
+Do you want to see the error details?</source>
+        <translation>Извините, но что-то пошло не так.
+
+Хотите просмотреть подробную информацию об ошибке?</translation>
+    </message>
+</context>
+</TS>

--- a/Programs/TeXAndFriends/pdftex/pdftex/po/ru/miktex-pdftex.po
+++ b/Programs/TeXAndFriends/pdftex/pdftex/po/ru/miktex-pdftex.po
@@ -1,0 +1,32 @@
+# Russian translations for MiKTeX package.
+# Copyright (C) 2021 THE MiKTeX'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the work package.
+# Christian Schenk <cs@miktex.org>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: work 3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-02 19:34+0200\n"
+"PO-Revision-Date: 2026-02-24 10:11+0300\n"
+"Last-Translator: Danil Kostenkov <danilkostenkov38@gmail.com>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: miktex-pdftex.h:219 miktex-pdftex.h:221
+msgid "Switch on draft mode (generates no output)."
+msgstr "Включить режим черновика (не генерирует выходных данных)."
+
+#: miktex-pdftex.h:220 miktex-pdftex.h:222
+msgid "Set the output format."
+msgstr "Установить выходной формат."
+
+#: miktex-pdftex.h:245 miktex-pdftex.h:247
+msgid "Unknown output format value."
+msgstr "Неизвестное значение выходного формата."


### PR DESCRIPTION
Add Russian localization files for multiple MiKTeX components. New .po and .ts files provide translated strings for App, Setup, TeXAndFriends (texmf), UI/Qt, Console/Qt and pdftex, bringing Russian UI and command-line messages to the distribution. Includes translations contributed by Danil Kostenkov. Closes #1725