### PR TITLE
Identify main documentation file for *__doc packages in MiKTex Console Documentation page

### DIFF
--- a/Programs/MiKTeX/Console/Qt/DocumentationTableModel.cpp
+++ b/Programs/MiKTeX/Console/Qt/DocumentationTableModel.cpp
@@ -40,7 +40,16 @@ struct DocumentSorter
     DocumentSorter(const std::string& packageId)
         : packageId(packageId)
     {
-        preferredNames[0] = packageId;
+        // Set preferred name of 'pkg_name__doc' to 'pkg_name';
+        if (packageId.size() > 5
+            && (packageId.compare(packageId.size()-5,std::string::npos,"__doc")==0))
+        {
+            preferredNames[0] = packageId.substr(0,packageId.size()-5);
+        }
+        else
+        {
+            preferredNames[0] = packageId;
+        }
     }
     bool operator() (const std::string& l, const std::string& r)
     {


### PR DESCRIPTION
Currently, the Documentation page in MiKTex Console lists one main documentation file per package. If there exists a documentation file of which the name (excluding extension) that matches the package name, this file is selected, otherwise the first alphabetically ordered file name is used (subject to hierarchy of preferred file types). This works fine for non-split packages, but where there is a separate `pkgname__doc` package (e.g. `biblatex__doc`, `todonotes__doc`) the actual main pdf (`biblatex.pdf`, `todonotes.pdf`) is missed in favour of an alphabetically earlier one in the folder (`examples/01-introduction-biber.pdf`, `examples/alterAppearanceOfListOfTodos.pdf` respectively)

This PR sets the preferred name of packages of the form `pkgname__doc` to `pkgname`, so that the main documentation file is found as would have been if the package was not split.

Tested & working on Ubuntu 24.04 (WSL)